### PR TITLE
brew-bootstrap-rbenv-ruby: store only one output from ruby-build

### DIFF
--- a/cmd/brew-bootstrap-rbenv-ruby
+++ b/cmd/brew-bootstrap-rbenv-ruby
@@ -11,7 +11,9 @@ fi
 
 if ! rbenv version-name &>/dev/null; then
   RUBY_REQUESTED="$(rbenv local)"
-  RUBY_DEFINITION="$(ruby-build --definitions | grep "^$RUBY_REQUESTED$")"
+  RUBY_DEFINITION="$(ruby-build --definitions |\
+    grep "^$RUBY_REQUESTED$" |\
+    tail -1)"
 
   if [ -z "$RUBY_DEFINITION" ]; then
     RUBY_DEFINITION="$BASE_PATH/ruby-definitions/$RUBY_REQUESTED"


### PR DESCRIPTION
This fixes `brew bootstrap-rbenv-ruby`.
