### PR TITLE
brew-report-issue: report/close project issues.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+script:
+  - bash -n cmd/*
+  - ruby -wc cmd/*.rb >/dev/null

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,19 @@
+Copyright (C) 2016 by GitHub
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,24 @@
 A series of helper scripts to reduce duplication across `script/bootstrap`s.
 
 - [`brew bootstrap-rbenv-ruby`](cmd/brew-bootstrap-rbenv-ruby): Installs Ruby and Bundler.
+- [`brew report-issue`](cmd/brew-report-issue.rb): Creates and closes failure debugging issues on a project.
 - [`brew bootstrap-nodenv-node`](cmd/brew-bootstrap-nodenv-node): Installs Node and npm.
 - [`brew setup-nginx-conf`](cmd/brew-setup-nginx-conf): Generates and installs a project nginx configuration using erb.
 - [`ruby-definitions/`](ruby-definitions): `ruby-build` definitions for GitHub Rubies (from [boxen/puppet-ruby](https://github.com/boxen/puppet-ruby/tree/master/files/definitions)).
+
+## Usage
+
+```bash
+brew tap github/bootstrap
+brew bootstrap-rbenv-ruby # or any other script
+```
+
+## Status
+In active development.
+
+## Contact
+[@mikemcquaid](https://github.com/mikemcquaid/)
+
+## License
+Homebrew Bootstrap is licensed under the [MIT License](http://en.wikipedia.org/wiki/MIT_License).
+The full license text is available in [LICENSE.txt](https://github.com/github/homebrew-bootstrap/blob/master/LICENSE.txt).

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ brew bootstrap-rbenv-ruby # or any other script
 ## Status
 In active development.
 
+[![Build Status](https://travis-ci.org/github/homebrew-bootstrap.svg)](https://travis-ci.org/github/homebrew-bootstrap)
+
 ## Contact
 [@mikemcquaid](https://github.com/mikemcquaid/)
 

--- a/cmd/brew-report-issue.rb
+++ b/cmd/brew-report-issue.rb
@@ -1,5 +1,5 @@
 #!/usr/bin/env ruby
-# Creates and closes issues on a project.
+# Creates and closes failure debugging issues on a project.
 close = !!ARGV.delete("--close")
 user_repo = ARGV.shift
 message = ARGV.shift

--- a/cmd/brew-report-issue.rb
+++ b/cmd/brew-report-issue.rb
@@ -67,19 +67,8 @@ def response_check response, action
   exit 1
 end
 
-def json_escape string
-  JSON.generate string, quirks_mode: true
-end
-
 def create_issue user_repo, title, body
-  title_json_string = json_escape title
-  body_json_string = json_escape body.chomp
-  new_issue_json = <<-EOS
-    {
-      "title": #{title_json_string},
-      "body":  #{body_json_string}
-    }
-  EOS
+  new_issue_json = { title: title, body: body }.to_json
   issues_url = "https://api.github.com/repos/#{user_repo}/issues"
   response = http_request :post, issues_url, new_issue_json
   response_check response, "create issue (#{issues_url})"
@@ -90,8 +79,7 @@ end
 
 def comment_issue issue, comment_body, options={}
   comments_url = issue["comments_url"]
-  body_json_string = json_escape comment_body.chomp
-  issue_comment_json = "{ \"body\": #{body_json_string} }"
+  issue_comment_json = { body: comment_body }.to_json
   response = http_request :post, comments_url, issue_comment_json
   response_check response, "create comment (#{comments_url})"
   puts "Commented on issue: #{issue["html_url"]}" if options[:notify]
@@ -99,7 +87,7 @@ end
 
 def close_issue issue
   issue_url = issue["url"]
-  close_issue_json = '{ "state": "closed" }'
+  close_issue_json = { state: "closed" }.to_json
   response = http_request :post, issue_url, close_issue_json
   response_check response, "close issue (#{issue_url})"
 end

--- a/cmd/brew-report-issue.rb
+++ b/cmd/brew-report-issue.rb
@@ -1,0 +1,105 @@
+#!/usr/bin/env ruby
+# Creates and closes issues on a project.
+close = !!ARGV.delete("--close")
+user_repo = ARGV.shift
+failure_source = ARGV.shift
+success_meta = failure_source
+
+if user_repo.to_s.empty? || failure_source.to_s.empty?
+  abort "Usage: brew report-issue [--close] <user/repo> <failure-source|success-meta> [<STDIN piped body>]"
+end
+
+unless close
+  abort "Error: the issue's body should be piped over STDIN!" if STDIN.tty?
+  issue_body = STDIN.read
+end
+
+github_credentials=`printf "protocol=https\nhost=github.com\n" | git credential fill 2>/dev/null`
+/username=(?<github_username>.+)/ =~ github_credentials
+/password=(?<github_password>.+)/ =~ github_credentials
+github_username ||= ENV["BOXEN_GITHUB_LOGIN"]
+github_username ||= `git config github.user`.chomp
+
+if github_username.to_s.empty?
+  abort <<-EOS
+Error: your GitHub username is not set! Set it by running Strap:
+  https://strap.githubapp.com
+EOS
+end
+@github_username = github_username
+
+if github_password.to_s.empty?
+  abort <<-EOS
+Error: your GitHub password is not set! Set it by running Strap:
+  https://strap.githubapp.com
+EOS
+end
+@github_password = github_password
+
+require "net/http"
+require "json"
+
+def http_request(type, url, body=nil)
+  uri = URI url
+  request = if type == :post
+    post_request = Net::HTTP::Post.new uri
+    post_request.body = body
+    post_request
+  elsif type == :get
+    Net::HTTP::Get.new uri
+  end
+  return unless request
+  request.basic_auth @github_username, @github_password
+  Net::HTTP.start(uri.hostname, uri.port, use_ssl: true) do |http|
+    http.request request
+  end
+end
+
+def response_check(response, action)
+  return if response.is_a? Net::HTTPSuccess
+  STDERR.puts "Error: failed to #{action}!"
+  unless response.body.empty?
+    failure = JSON.parse(response.body)
+    STDERR.puts "--\n#{response.code}: #{failure["message"] }"
+  end
+  exit 1
+end
+
+def json_escape(string)
+  JSON.generate(string, quirks_mode: true)
+end
+
+if close
+  closed_issues_url = \
+    "https://api.github.com/repos/#{user_repo}/issues?filter=created"
+  response = http_request :get, closed_issues_url
+  response_check(response, "get issues (#{closed_issues_url})")
+
+  issues = JSON.parse response.body
+  issues.each do |issue|
+    comments_url = issue["comments_url"]
+    succeeded = json_escape "Succeeded at #{success_meta}."
+    issue_comment_json = "{ \"body\": #{succeeded} }"
+    response = http_request :post, comments_url, issue_comment_json
+    response_check(response, "create comment (#{comments_url})")
+
+    issue_url = issue["url"]
+    close_issue_json = '{ "state": "closed" }'
+    response = http_request :post, issue_url, close_issue_json
+    response_check(response, "close issue (#{issue_url})")
+  end
+else
+  title = json_escape "#{failure_source} failed for #{@github_username}"
+  body = json_escape issue_body.chomp
+  new_issue_json = <<-EOS
+    {
+      "title": #{title},
+      "body":  #{body}
+    }
+  EOS
+  issues_url = "https://api.github.com/repos/#{user_repo}/issues"
+  response = http_request :post, issues_url, new_issue_json
+  response_check(response, "create issue (#{issues_url})")
+  issue = JSON.parse(response.body)
+  puts "Created issue: #{issue["html_url"]}"
+end

--- a/cmd/brew-report-issue.rb
+++ b/cmd/brew-report-issue.rb
@@ -9,8 +9,8 @@ if user_repo.to_s.empty? || message.to_s.empty?
 end
 
 unless close
-  abort "Error: the issue's body should be piped over STDIN!" if STDIN.tty?
-  issue_body = STDIN.read
+  abort "Error: the issue/comment body should be piped over STDIN!" if STDIN.tty?
+  body = STDIN.read
 end
 
 github_credentials=`printf "protocol=https\nhost=github.com\n" | git credential fill 2>/dev/null`
@@ -116,8 +116,8 @@ if close
   end
 elsif open_issues.any?
   issue = open_issues.first
-  comment_issue issue, issue_body, notify: true
+  comment_issue issue, body, notify: true
 else
   title = "#{message} failed for #{@github_username}"
-  create_issue user_repo, title, issue_body
+  create_issue user_repo, title, body
 end

--- a/cmd/brew-report-issue.rb
+++ b/cmd/brew-report-issue.rb
@@ -19,10 +19,13 @@ github_credentials=`printf "protocol=https\nhost=github.com\n" | git credential 
 github_username ||= ENV["BOXEN_GITHUB_LOGIN"]
 github_username ||= `git config github.user`.chomp
 
+strap_url = ENV["STRAP_URL"]
+strap_url ||= "https://strap.githubapp.com"
+
 if github_username.to_s.empty?
   abort <<-EOS
 Error: your GitHub username is not set! Set it by running Strap:
-  https://strap.githubapp.com
+  #{strap_url}
 EOS
 end
 @github_username = github_username
@@ -30,7 +33,7 @@ end
 if github_password.to_s.empty?
   abort <<-EOS
 Error: your GitHub password is not set! Set it by running Strap:
-  https://strap.githubapp.com
+  #{strap_url}
 EOS
 end
 @github_password = github_password

--- a/cmd/brew-setup-nginx-conf
+++ b/cmd/brew-setup-nginx-conf
@@ -45,8 +45,14 @@ end
 
 exit unless RUBY_PLATFORM.include? "darwin"
 
+strap_url = ENV["STRAP_URL"]
+strap_url ||= "https://strap.githubapp.com"
+
 unless File.exist? "/usr/local/bin/brew"
-  abort "Error: Homebrew is not in /usr/local. Run https://strap.githubapp.com."
+  abort <<-EOS
+Error: Homebrew is not in /usr/local. Install it by running Strap:
+  #{strap_url}
+EOS
 end
 
 brewfile = <<-EOS


### PR DESCRIPTION
This script has two modes: filing issues and closing them.

When filing issues the body is piped in over STDIN and the issue title and repository specified on the command-line. To avoid noise: this should probably only be used on dedicated repositories for these issues as they may be autoposted frequently.

When closing issues all issues filed by the user will be closed on the repository and a comment with the success state will be posted to each of the issues.

GitHub API credentials are extracted based on access to HTTPS GitHub repositories.

This tool is designed to behave similarly to how Boxen did and will be used by projects for autoposting issues.

CC @github/friction @github/workflow-tools 