### PR TITLE
brew-report-issue: setup Git credentials.

### DIFF
--- a/cmd/brew-report-issue.rb
+++ b/cmd/brew-report-issue.rb
@@ -74,11 +74,11 @@ end
 
 def response_check response, action
   return if response.is_a? Net::HTTPSuccess
+  # If there's bad credentials, erase them.
+  credential_helper :erase, @github_credentials if response.code == "401"
   STDERR.puts "Error: failed to #{action}!"
   unless response.body.empty?
     failure = JSON.parse response.body
-    # If there's bad credentials, erase them.
-    credential_helper :erase, @github_credentials if response.code == "401"
     STDERR.puts "--\n#{response.code}: #{failure["message"] }"
   end
   exit 1

--- a/cmd/brew-report-issue.rb
+++ b/cmd/brew-report-issue.rb
@@ -49,7 +49,7 @@ def credential_helper(command, input)
   `printf "#{input}" | git credential-#{@credential_helper} #{command}`
 end
 
-if credential_helper(:get, @github_credentials).to_s.empty?
+if credential_helper(:get, @github_credentials).to_s.chomp.empty?
   credential_helper :store, @github_credentials
 end
 


### PR DESCRIPTION
`git credential fill` prompts for but does not save any credentials.
Instead of asking for them every time look for a credential helper, ask for the credentials once, store them and invalidate them if authentication failed. For edge-cases: tell people to use Strap which sets this all up for them instead.

CC @scottjg @nakajima