### PR TITLE
brew-report-issue: fix Boxen credential handler.

### DIFF
--- a/cmd/brew-report-issue.rb
+++ b/cmd/brew-report-issue.rb
@@ -24,7 +24,8 @@ EOS
 end
 
 def credential_helper(command, input)
-  IO.popen(["git", "credential", "#{command}"], "w+", err: "/dev/null") do |io|
+  IO.popen({"RUBYLIB" => nil, "RUBYOPT" => nil},
+           ["git", "credential", "#{command}"], "w+") do |io|
     io.puts input
     io.close_write
     io.read


### PR DESCRIPTION
Firstly, allow errors to be outputted to aid in debugging.

Secondly, unset `RUBYLIB` and `RUBYOPT` in case they are set to invalid values for the system Ruby which Boxen uses for its credential handler.

Thanks to @amosie for letting me debug this on her machine!