### PR TITLE
brew-report-issue: provide more help on a 401.

### DIFF
--- a/cmd/brew-report-issue.rb
+++ b/cmd/brew-report-issue.rb
@@ -82,6 +82,12 @@ def response_check response, action
     failure = JSON.parse response.body
     STDERR.puts "--\n#{response.code}: #{failure["message"] }"
   end
+  if response.code == "401"
+    STDERR.puts <<-EOS
+Error: your GitHub username/access token are not correct! Fix by running Strap:
+  #{strap_url}
+EOS
+  end
   exit 1
 end
 


### PR DESCRIPTION
Point people towards the fact that it needs to be an access token rather than password and these can be set by running Strap.

CC @github/friction and thanks to @davidcelis for the suggestion in https://github.com/github/github-bootstrap-failures/issues/26