### PR TITLE
Tweak rbenv/nodenv error messaging.

### DIFF
--- a/cmd/brew-bootstrap-nodenv-node
+++ b/cmd/brew-bootstrap-nodenv-node
@@ -44,7 +44,7 @@ if ! nodenv version-name &>/dev/null; then
 fi
 
 if [ "$(nodenv exec node --version)" != "$(node --version)" ]; then
-  abort 'You need to add `eval "$(nodenv init -)"` to your .bash_profile/.bashrc/.zshrc!'
+  abort 'Error: add `eval "$(nodenv init -)"` to the end of your .bash_profile/.zshrc!'
 fi
 
 EXPECTED_EXIT="1"

--- a/cmd/brew-bootstrap-rbenv-ruby
+++ b/cmd/brew-bootstrap-rbenv-ruby
@@ -50,7 +50,7 @@ if ! rbenv version-name &>/dev/null; then
 
   rbenv install --skip-existing "$RUBY_DEFINITION"
   if [ "$(rbenv exec ruby --version)" != "$(ruby --version)" ]; then
-    abort 'You need to add `eval "$(rbenv init -)"` to your .bash_profile/.bashrc/.zshrc!'
+    abort 'Error: add `eval "$(rbenv init -)"` to the end of your .bash_profile/.zshrc!'
   fi
 fi
 


### PR DESCRIPTION
Addresses an issue where @nixpad added this before the end of her `.bash_profile` and as a result the `$PATH` wasn't set correct.

@nixpad would this message have made it clearer? If not, do you have a suggestion of what might? Thanks!

CC @github/friction for :thought_balloon:.