### PR TITLE
Upgrade OpenSSL to v1.0.2g

### DIFF
--- a/ruby-definitions/2.0.0-github
+++ b/ruby-definitions/2.0.0-github
@@ -1,3 +1,3 @@
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#5fe00cda18ca5daeb43762b80c38e06e" --if needs_yaml
-install_package "openssl-1.0.1h" "https://www.openssl.org/source/openssl-1.0.1h.tar.gz#8d6d684a9430d5cc98a62a5d8fbda8cf" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.0.0-github6" "https://s3.amazonaws.com/boxen-downloads/ruby-build/ruby-2.0.0-github6.tar.gz#63e06d012a10a66898def8afdba111ea" autoconf standard verify_openssl

--- a/ruby-definitions/2.1.0-github
+++ b/ruby-definitions/2.1.0-github
@@ -1,3 +1,3 @@
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#5fe00cda18ca5daeb43762b80c38e06e" --if needs_yaml
-install_package "openssl-1.0.1h" "https://www.openssl.org/source/openssl-1.0.1h.tar.gz#8d6d684a9430d5cc98a62a5d8fbda8cf" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.1.0-github1" "https://s3.amazonaws.com/boxen-downloads/ruby-build/ruby-2.1.0-github1.tar.gz#a8b528f2e0d5ecf55893002078014beb" ldflags_dirs autoconf standard verify_openssl

--- a/ruby-definitions/2.1.1-github
+++ b/ruby-definitions/2.1.1-github
@@ -1,3 +1,3 @@
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#5fe00cda18ca5daeb43762b80c38e06e" --if needs_yaml
-install_package "openssl-1.0.1h" "https://www.openssl.org/source/openssl-1.0.1h.tar.gz#8d6d684a9430d5cc98a62a5d8fbda8cf" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.1.1-github1" "https://s3.amazonaws.com/boxen-downloads/ruby-build/ruby-2.1.1-github1.tar.gz#dd81268aaa87a7b200f40ad53ac47227" ldflags_dirs autoconf standard verify_openssl

--- a/ruby-definitions/2.1.2-github
+++ b/ruby-definitions/2.1.2-github
@@ -1,3 +1,3 @@
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#5fe00cda18ca5daeb43762b80c38e06e" --if needs_yaml
-install_package "openssl-1.0.1h" "https://www.openssl.org/source/openssl-1.0.1h.tar.gz#8d6d684a9430d5cc98a62a5d8fbda8cf" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.1.2-github1" "https://s3.amazonaws.com/boxen-downloads/ruby-build/ruby-2.1.2-github1.tar.gz#3728f9ce8fc87aca1fef40d201358fa2" ldflags_dirs autoconf standard verify_openssl

--- a/ruby-definitions/2.1.4-github
+++ b/ruby-definitions/2.1.4-github
@@ -1,3 +1,3 @@
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#5fe00cda18ca5daeb43762b80c38e06e" --if needs_yaml
-install_package "openssl-1.0.1j" "https://www.openssl.org/source/openssl-1.0.1j.tar.gz#f7175c9cd3c39bb1907ac8bba9df8ed3" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.1.4-github1" "https://s3.amazonaws.com/boxen-downloads/ruby-build/ruby-2.1.4-github1.tar.gz#2e538443e5ce80da1d922153d1422439" ldflags_dirs autoconf standard verify_openssl

--- a/ruby-definitions/2.1.5-github
+++ b/ruby-definitions/2.1.5-github
@@ -1,3 +1,3 @@
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
-install_package "openssl-1.0.1l" "https://www.openssl.org/source/openssl-1.0.1l.tar.gz#b2cf4d48fe5d49f240c61c9e624193a6f232b5ed0baf010681e725963c40d1d4" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2_1_5_github1" "https://github.com/github/ruby/archive/v2_1_5_github1.tar.gz#003d09f172a16979c3eae7a91a46ee1db986d9c35f2d905f3c459d092f55fdf8" ldflags_dirs autoconf standard verify_openssl

--- a/ruby-definitions/2.1.6-github
+++ b/ruby-definitions/2.1.6-github
@@ -1,3 +1,3 @@
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
-install_package "openssl-1.0.1m" "https://www.openssl.org/source/openssl-1.0.1m.tar.gz#095f0b7b09116c0c5526422088058dc7e6e000aa14d22acca6a4e2babcdfef74" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2_1_6_github1" "https://github.com/github/ruby/archive/v2_1_6_github1.tar.gz#c874bb4aa16debc37e55f2b021f1970fb527be1053ce3a9a30a2a67848959b65" ldflags_dirs autoconf standard verify_openssl

--- a/ruby-definitions/2.1.7-github
+++ b/ruby-definitions/2.1.7-github
@@ -1,3 +1,3 @@
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
-install_package "openssl-1.0.1m" "https://www.openssl.org/source/openssl-1.0.1m.tar.gz#095f0b7b09116c0c5526422088058dc7e6e000aa14d22acca6a4e2babcdfef74" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2_1_7_github1" "https://github.com/github/ruby/archive/v2_1_7_github1.tar.gz#49fbdc6ee015b21f5b056ef847912ee8f0ae5afd9d1d2564e066e4679923a5e0" ldflags_dirs autoconf standard verify_openssl


### PR DESCRIPTION
Hey! @mikemcquaid, is this of interest to you? Was upgrading my [ruby-build-github specs](https://github.com/parkr/ruby-build-github/commit/b6f88076ec3a3aed571e2db4e567decb4dce0656) and figured I would suggest it here as well.

Thanks!