### PR TITLE
Set up nodenv/rbenv automatically

### DIFF
--- a/cmd/brew-bootstrap-nodenv-node
+++ b/cmd/brew-bootstrap-nodenv-node
@@ -32,6 +32,12 @@ if ! which nodenv &>/dev/null; then
   abort "Error: you need to 'brew install nodenv'!"
 fi
 
+if [ $(type -t nodenv) != 'function' ]; then
+  warn "Warning: setting up nodenv temporarily."
+  warn "You may need to set it up in your shell; check \`brew info nodenv\`"
+  eval "$(nodenv init -)"
+fi
+
 if ! nodenv version-name &>/dev/null; then
   NODE_REQUESTED="$(nodenv local)"
   NODE_DEFINITION="$(node-build --definitions | grep "^$NODE_REQUESTED$" || true)"
@@ -41,10 +47,6 @@ if ! nodenv version-name &>/dev/null; then
   fi
 
   nodenv install "$NODE_DEFINITION"
-fi
-
-if [ "$(nodenv exec node --version)" != "$(node --version)" ]; then
-  abort 'Error: add `eval "$(nodenv init -)"` to the end of your .bash_profile/.zshrc!'
 fi
 
 EXPECTED_EXIT="1"

--- a/cmd/brew-bootstrap-rbenv-ruby
+++ b/cmd/brew-bootstrap-rbenv-ruby
@@ -55,9 +55,6 @@ if ! rbenv version-name &>/dev/null; then
   export RUBY_CONFIGURE_OPTS="--with-openssl-dir=$HOMEBREW_PREFIX/opt/openssl"
 
   rbenv install --skip-existing "$RUBY_DEFINITION"
-  if [ "$(rbenv exec ruby --version)" != "$(ruby --version)" ]; then
-    abort 'Error: add `eval "$(rbenv init -)"` to the end of your .bash_profile/.zshrc!'
-  fi
 fi
 
 (which bundle &>/dev/null && bundle -v &>/dev/null) || {

--- a/cmd/brew-bootstrap-rbenv-ruby
+++ b/cmd/brew-bootstrap-rbenv-ruby
@@ -32,6 +32,12 @@ if ! which rbenv &>/dev/null; then
   abort "Error: you need to 'brew install rbenv'!"
 fi
 
+if [ $(type -t rbenv) != 'function' ]; then
+  warn "Warning: setting up rbenv temporarily."
+  warn "You may need to set it up in your shell; check \`brew info rbenv\`"
+  eval "$(rbenv init -)"
+fi
+
 if ! rbenv version-name &>/dev/null; then
   RUBY_REQUESTED="$(rbenv local)"
   RUBY_DEFINITION="$(ruby-build --definitions | grep "^$RUBY_REQUESTED$" || true)"


### PR DESCRIPTION
When calling the brew-bootstrap scripts, eval the nodenv/rbenv init steps automatically instead of errorring out if the user hasn't done it themselves.

Erroring out causes script/bootstrap calls to fail; it's probably preferable to warn the user to do this for their shell and keep going, rather than cause the script which called the bootstrap step to fail.

This was inspired by comments like https://github.com/github/atom.io/pull/983#issuecomment-199252473 - users are either using alternate systems or haven't set up nodenv/rbenv in their shells yet, and in either case it's preferable for those users to let script/bootstrap complete and take care of things then, instead of having it bail out mid-run. I'm not actually clear on whether nodenv/rbenv need to be initted in the shell in this context; it might be sufficient just to warn the user without actually evalling the `init` step.