### PR TITLE
Look up bundler within the active ruby

### DIFF
--- a/cmd/brew-bootstrap-rbenv-ruby
+++ b/cmd/brew-bootstrap-rbenv-ruby
@@ -54,7 +54,7 @@ if ! rbenv version-name &>/dev/null; then
   fi
 fi
 
-(which bundle &>/dev/null && bundle -v &>/dev/null) || {
+(rbenv which bundle &>/dev/null && bundle -v &>/dev/null) || {
   gem install bundler
   rbenv rehash
 }


### PR DESCRIPTION
Otherwise a `bundle` from outside rbenv that comes first in the PATH will satisfy the check, e.g. `/usr/bin/bundle`

cc @mikemcquaid 