### PR TITLE
brew-bootstrap-rbenv-ruby: always check rbenv init

### DIFF
--- a/cmd/brew-bootstrap-rbenv-ruby
+++ b/cmd/brew-bootstrap-rbenv-ruby
@@ -49,9 +49,10 @@ if ! rbenv version-name &>/dev/null; then
   export RUBY_CONFIGURE_OPTS="--with-openssl-dir=$HOMEBREW_PREFIX/opt/openssl"
 
   rbenv install --skip-existing "$RUBY_DEFINITION"
-  if [ "$(rbenv exec ruby --version)" != "$(ruby --version)" ]; then
-    abort 'Error: add `eval "$(rbenv init -)"` to the end of your .bash_profile/.zshrc!'
-  fi
+fi
+
+if [ "$(rbenv exec ruby --version)" != "$(ruby --version)" ]; then
+  abort 'Error: add `eval "$(rbenv init -)"` to the end of your .bash_profile/.zshrc!'
 fi
 
 (rbenv which bundle &>/dev/null && bundle -v &>/dev/null) || {


### PR DESCRIPTION
Even if the correct `ruby` is installed we've got to make sure we check that the relevant `rbenv init` call has been run.

CC @mistydemeo and @tomkrouper who hit this.