### PR TITLE
Add per-shell setup instructions

### DIFF
--- a/cmd/brew-bootstrap-nodenv-node
+++ b/cmd/brew-bootstrap-nodenv-node
@@ -11,19 +11,19 @@ fi
 warn() { echo "$@" >&2; }
 abort() { EXPECTED_EXIT="1"; warn "$@"; exit 1; }
 
-warn_sh() {
+abort_for_sh() {
   abort 'Error: add `eval "$(nodenv init -)"` to the end of your .bash_profile!'
 }
 
-warn_zsh() {
+abort_for_zsh() {
   abort 'Error: add `eval "$(nodenv init -)"` to the end of your .zshrc!'
 }
 
-warn_fish() {
+abort_for_fish() {
   abort 'Error: add `status --is-interactive; and . (nodenv init -|psub)` to the end of your .config/fish/config.fish!'
 }
 
-warn_shell_setup() {
+abort_with_shell_setup_message() {
   case $(basename ${SHELL:-bash}) in
   sh|bash)
     warn_sh
@@ -73,7 +73,7 @@ if ! nodenv version-name &>/dev/null; then
 fi
 
 if [ "$(nodenv exec node --version)" != "$(node --version)" ]; then
-  warn_shell_setup
+  abort_with_shell_setup_message
 fi
 
 EXPECTED_EXIT="1"

--- a/cmd/brew-bootstrap-nodenv-node
+++ b/cmd/brew-bootstrap-nodenv-node
@@ -11,6 +11,35 @@ fi
 warn() { echo "$@" >&2; }
 abort() { EXPECTED_EXIT="1"; warn "$@"; exit 1; }
 
+warn_sh() {
+  abort 'Error: add `eval "$(nodenv init -)"` to the end of your .bash_profile!'
+}
+
+warn_zsh() {
+  abort 'Error: add `eval "$(nodenv init -)"` to the end of your .zshrc!'
+}
+
+warn_fish() {
+  abort 'Error: add `status --is-interactive; and . (nodenv init -|psub)` to the end of your .config/fish/config.fish!'
+}
+
+warn_shell_setup() {
+  case $(basename ${SHELL:-bash}) in
+  sh|bash)
+    warn_sh
+    ;;
+  zsh)
+    warn_zsh
+    ;;
+  fish)
+    warn_fish
+    ;;
+  # tcsh users are on their own
+  *)
+    abort 'Error: you must finish setting up nodenv in your shell; check `nodenv init` for instructions!'
+  esac
+}
+
 cleanup() {
   set +e
   if [ -n "$EXPECTED_EXIT" ]; then
@@ -44,7 +73,7 @@ if ! nodenv version-name &>/dev/null; then
 fi
 
 if [ "$(nodenv exec node --version)" != "$(node --version)" ]; then
-  abort 'Error: add `eval "$(nodenv init -)"` to the end of your .bash_profile/.zshrc!'
+  warn_shell_setup
 fi
 
 EXPECTED_EXIT="1"

--- a/cmd/brew-bootstrap-rbenv-ruby
+++ b/cmd/brew-bootstrap-rbenv-ruby
@@ -11,6 +11,35 @@ fi
 warn() { echo "$@" >&2; }
 abort() { EXPECTED_EXIT="1"; warn "$@"; exit 1; }
 
+warn_sh() {
+  abort 'Error: add `eval "$(rbenv init -)"` to the end of your .bash_profile!'
+}
+
+warn_zsh() {
+  abort 'Error: add `eval "$(rbenv init -)"` to the end of your .zshrc!'
+}
+
+warn_fish() {
+  abort 'Error: add `status --is-interactive; and . (rbenv init -|psub)` to the end of your .config/fish/config.fish!'
+}
+
+warn_shell_setup() {
+  case $(basename ${SHELL:-bash}) in
+  sh|bash)
+    warn_sh
+    ;;
+  zsh)
+    warn_zsh
+    ;;
+  fish)
+    warn_fish
+    ;;
+  # tcsh users are on their own
+  *)
+    abort 'Error: you must finish setting up rbenv in your shell; check `rbenv init` for instructions!'
+  esac
+}
+
 cleanup() {
   set +e
   if [ -n "$EXPECTED_EXIT" ]; then
@@ -52,7 +81,7 @@ if ! rbenv version-name &>/dev/null; then
 fi
 
 if [ "$(rbenv exec ruby --version)" != "$(ruby --version)" ]; then
-  abort 'Error: add `eval "$(rbenv init -)"` to the end of your .bash_profile/.zshrc!'
+  warn_shell_setup
 fi
 
 (rbenv which bundle &>/dev/null && bundle -v &>/dev/null) || {

--- a/cmd/brew-bootstrap-rbenv-ruby
+++ b/cmd/brew-bootstrap-rbenv-ruby
@@ -11,19 +11,19 @@ fi
 warn() { echo "$@" >&2; }
 abort() { EXPECTED_EXIT="1"; warn "$@"; exit 1; }
 
-warn_sh() {
+abort_for_sh() {
   abort 'Error: add `eval "$(rbenv init -)"` to the end of your .bash_profile!'
 }
 
-warn_zsh() {
+abort_for_zsh() {
   abort 'Error: add `eval "$(rbenv init -)"` to the end of your .zshrc!'
 }
 
-warn_fish() {
+abort_for_fish() {
   abort 'Error: add `status --is-interactive; and . (rbenv init -|psub)` to the end of your .config/fish/config.fish!'
 }
 
-warn_shell_setup() {
+abort_with_shell_setup_message() {
   case $(basename ${SHELL:-bash}) in
   sh|bash)
     warn_sh
@@ -81,7 +81,7 @@ if ! rbenv version-name &>/dev/null; then
 fi
 
 if [ "$(rbenv exec ruby --version)" != "$(ruby --version)" ]; then
-  warn_shell_setup
+  abort_with_shell_setup_message
 fi
 
 (rbenv which bundle &>/dev/null && bundle -v &>/dev/null) || {


### PR DESCRIPTION
Instead of having a single generic warning, sniff the value of `$SHELL` and provide a specific warning based on that. This should help some of the confusion Mike mentioned in #18. Supports `sh`/`bash`, `zsh`, and `fish`; `tcsh`-using cowgirls are on their own.

cc @mikemcquaid, @ErinCall 