### PR TITLE
brew-report-issue: check global Git configuration.

### DIFF
--- a/cmd/brew-report-issue.rb
+++ b/cmd/brew-report-issue.rb
@@ -16,7 +16,7 @@ end
 @strap_url = ENV["STRAP_URL"]
 @strap_url ||= "https://strap.githubapp.com"
 
-if `git config --global credential.helper`.chomp.empty?
+if `git config credential.helper`.chomp.empty?
   abort <<-EOS
 Error: your Git HTTP(S) credential helper is not set! Set it by running Strap:
 #{@strap_url}


### PR DESCRIPTION
When looking for a Git credential helper instead of demanding it is set in `~/.gitconfig` also allow it to be set at a project or system level (such as Apple's Git now does).