### PR TITLE
setup-nginx-conf: remove old /etc/resolver.

### DIFF
--- a/cmd/brew-setup-nginx-conf
+++ b/cmd/brew-setup-nginx-conf
@@ -73,6 +73,7 @@ if `readlink /etc/resolver 2>/dev/null`.chomp != "/usr/local/etc/resolver"
   unless system "sudo -n true >/dev/null"
     puts "Asking for your password to setup *.dev:"
   end
+  system "sudo rm -rf /etc/resolver"
   unless system "sudo ln -sf /usr/local/etc/resolver /etc/resolver"
     abort "Error: failed to symlink /usr/local/etc/resolver to /etc/resolver!"
   end


### PR DESCRIPTION
This [mirrors what github/github does](https://github.com/github/github/blob/0650820e9d68f97145fc0474d1ddb0270a4198e3/script/osx-setup#L71-L72) and avoids accidentally creating e.g. `/etc/resolver/resolver`.

CC @bhuga @snh @josh 

Closes https://github.com/github/developer-experience/issues/206.