### PR TITLE
Drop launch_socket_server from setup-nginx-conf

### DIFF
--- a/cmd/brew-setup-nginx-conf
+++ b/cmd/brew-setup-nginx-conf
@@ -57,7 +57,6 @@ end
 
 brewfile = <<-EOS
 brew "launchdns", restart_service: true
-brew "launch_socket_server"
 brew "nginx", restart_service: true
 EOS
 
@@ -82,7 +81,7 @@ end
 
 if File.exist? "/etc/pf.anchors/dev.strap"
   unless system "sudo -n true >/dev/null"
-    puts "Asking for your password to setup launch_socket_server:"
+    puts "Asking for your password to uninstall pf:"
   end
   system "sudo rm /etc/pf.anchors/dev.strap"
   system "sudo grep -v 'dev.strap' /etc/pf.conf | sudo tee /etc/pf.conf"
@@ -101,11 +100,5 @@ system "brew prune >/dev/null"
 unless started_services
   unless system "brew services restart nginx >/dev/null"
     abort "Error: failed to (re)start nginx!"
-  end
-  unless system "sudo -n true >/dev/null"
-    puts "Asking for your password to restart launch_socket_server:"
-  end
-  unless system "sudo brew services restart launch_socket_server >/dev/null"
-    abort "Error: failed to (re)start launch_socket_server!"
   end
 end

--- a/cmd/brew-setup-nginx-conf
+++ b/cmd/brew-setup-nginx-conf
@@ -57,6 +57,7 @@ end
 
 brewfile = <<-EOS
 brew "launchdns", restart_service: true
+brew "launch_socket_server"
 brew "nginx", restart_service: true
 EOS
 
@@ -90,6 +91,15 @@ if File.exist? "/etc/pf.anchors/dev.strap"
   system "sudo launchctl unload /Library/LaunchDaemons/dev.strap.pf.plist 2>/dev/null"
   system "sudo rm -f /Library/LaunchDaemons/dev.strap.pf.plist"
 end
+if `brew services list | grep launch_socket_server | grep started` == ''
+  unless system "sudo -n true > /dev/null"
+    puts "Asking for your password to start launch_socket_server:"
+  end
+  unless system "sudo brew services start launch_socket_server >/dev/null"
+    abort "Error: failed to start launch_socket_server!"
+  end
+end
+
 
 server = "/usr/local/etc/nginx/servers/#{name}"
 unless system "ln -sf '#{File.absolute_path(output)}' '#{server}'"


### PR DESCRIPTION
As far as I know, everything's using ports now, rather than sockets. By getting rid of launch_socket_server we can avoid needing sudo in the normal case.

Needing sudo has been a pain for me because of a handful of script/test files that call script/bootstrap which calls setup-nginx-conf. Needing sudo to run tests is silly.
