### PR TITLE
Fix cmd name when no params given

### DIFF
--- a/cmd/brew-setup-nginx-conf
+++ b/cmd/brew-setup-nginx-conf
@@ -17,7 +17,7 @@ root = ARGV.shift || "."
 input = ARGV.shift || "config/dev/nginx.conf.erb"
 
 if !name || !root || !input
-  abort "Usage: brew generate-nginx-conf [--root] <project_name> <project_root_path> <nginx.conf.erb>"
+  abort "Usage: brew setup-nginx-conf [--root] <project_name> <project_root_path> <nginx.conf.erb>"
 end
 
 unless input.end_with? ".erb"


### PR DESCRIPTION
Show `setup` instead of `generate` when aborting.
