### PR TITLE
Fix ERB interpolation in brew-setup-nginx-conf

### DIFF
--- a/cmd/brew-setup-nginx-conf.rb
+++ b/cmd/brew-setup-nginx-conf.rb
@@ -26,7 +26,7 @@ root = File.expand_path root
 input = File.expand_path input
 
 data = IO.read input
-conf = ERB.new(data).result
+conf = ERB.new(data).result(binding)
 output = input.sub(/.erb$/, "")
 output.sub!(/.conf$/, ".root.conf") if root_configuration
 IO.write output, conf


### PR DESCRIPTION
This fixes a problem that #43 seems to have triggered for myself and @phantomdata, whereby no project that uses `brew setup-nginx-conf` in its bootstrap can successfully interpolate the ERB file. I tested this with three separate projects (halp, githubber.tv and docsotron), and all three returned similar errors:

```
Error: undefined local variable or method `root' for main:Object
(erb):2:in `<main>'
/usr/local/Homebrew/Library/Homebrew/vendor/portable-ruby/2.3.3/lib/ruby/2.3.0/erb.rb:864:in `eval'
/usr/local/Homebrew/Library/Homebrew/vendor/portable-ruby/2.3.3/lib/ruby/2.3.0/erb.rb:864:in `result'
/usr/local/Homebrew/Library/Taps/github/homebrew-bootstrap/cmd/brew-setup-nginx-conf.rb:29:in `<top (required)>'
/usr/local/Homebrew/Library/Homebrew/vendor/portable-ruby/2.3.3/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
/usr/local/Homebrew/Library/Homebrew/vendor/portable-ruby/2.3.3/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
/usr/local/Homebrew/Library/Homebrew/utils.rb:20:in `require?'
/usr/local/Homebrew/Library/Homebrew/brew.rb:106:in `<main>'
```

The variable changes, but the stack trace is the same. The problem seems to be that ERB doesn't have access to the local variables set up in the script, and so the `binding` needs to be passed in to access them.

This fixes all three projects... but what I can't figure out is why it worked in the first place, and why the change in #43 would've broken it. Most of the documentation/howtos I looked up suggested that passing in the current `binding` to `result` was required if you needed access to local variables, and I haven't seen anything just yet that suggests the binding wouldn't be necessary in any circumstance. Only thing I can think of is some sort of not-particularly visible setting or library version change, but I haven't narrowed that down yet.

So that's a bit of a stumper, but this does fix the problem, so going to go ahead and get some :eyes: (and maybe other 💭) on it 😅 

cc: @MikeMcQuaid for review