### PR TITLE
Add command to upgrade homebrew MySQL 5.6 to 5.7

### DIFF
--- a/cmd/brew-upgrade-mysql
+++ b/cmd/brew-upgrade-mysql
@@ -21,28 +21,15 @@ sql_mode=NO_ENGINE_SUBSTITUTION
 EOM
 }
 
-set +e
-brew ls mysql@5.6 &>/dev/null
-MYSQL_5_6="$?"
 
-brew ls mysql@5.7 &>/dev/null
-MYSQL_5_7="$?"
-set -e
-
-if [[ $MYSQL_5_6 == "0" || $MYSQL_5_7 == "0" ]]; then
-  if [[ $MYSQL_5_6 == "0" ]]; then
-    set +e
-    brew services stop mysql@5.6
-    set -e
-
-    brew uninstall mysql@5.6
+if [[ -d $(brew --prefix mysql@5.6) || -d $(brew --prefix mysql@5.7) ]]; then
+  if [[ -d $(brew --prefix mysql@5.6) ]]; then
+    brew services stop mysql@5.6 || true
     brew install mysql@5.7
   fi
 
-  if [[ $MYSQL_5_7 == "0" ]]; then
-    set +e
-    brew services stop mysql@5.7
-    set -e
+  if [[ -d $(brew --prefix mysql@5.7) ]]; then
+    brew services stop mysql@5.7 || true
   fi
 
   update_my_cnf
@@ -55,7 +42,7 @@ if [[ $MYSQL_5_6 == "0" || $MYSQL_5_7 == "0" ]]; then
   done
 
   $(brew --prefix mysql@5.7)/bin/mysql_upgrade -u root
-  brew services stop mysql@5.7
+  brew services restart mysql@5.7
   brew services start mysql@5.7
 fi
 

--- a/cmd/brew-upgrade-mysql
+++ b/cmd/brew-upgrade-mysql
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+set -e
+
+update_my_cnf() {
+  CNF_PATH="$(brew --prefix)/etc/my.cnf"
+
+  echo "Backing up old my.cnf file..."
+  cp -vf $CNF_PATH "$CNF_PATH.github"
+
+  cat > $CNF_PATH <<-EOM
+# For advice on how to change settings please see
+# http://dev.mysql.com/doc/refman/5.7/en/server-configuration-defaults.html
+
+[mysqld]
+
+innodb_strict_mode=OFF
+optimizer_switch='index_merge_intersection=OFF'
+query_cache_size=0
+sql_mode=NO_ENGINE_SUBSTITUTION
+EOM
+}
+
+set +e
+brew ls mysql@5.6 &>/dev/null
+MYSQL_5_6="$?"
+
+brew ls mysql@5.7 &>/dev/null
+MYSQL_5_7="$?"
+set -e
+
+if [[ $MYSQL_5_6 == "0" || $MYSQL_5_7 == "0" ]]; then
+  if [[ $MYSQL_5_6 == "0" ]]; then
+    set +e
+    brew services stop mysql@5.6
+    set -e
+
+    brew uninstall mysql@5.6
+    brew install mysql@5.7
+  fi
+
+  if [[ $MYSQL_5_7 == "0" ]]; then
+    set +e
+    brew services stop mysql@5.7
+    set -e
+  fi
+
+  update_my_cnf
+
+  # Upgrade the MySQL tables
+  echo "Upgrading MySQL Tables ..."
+  brew services start mysql@5.7
+
+  while ! nc -z localhost 3306; do
+    echo "Waiting for MySQL to be available..."
+    sleep 2
+  done
+
+  $(brew --prefix mysql@5.7)/bin/mysql_upgrade -u root
+  brew services stop mysql@5.7
+  brew services start mysql@5.7
+fi
+
+EXPECTED_EXIT="1"
+exit 0

--- a/cmd/brew-upgrade-mysql
+++ b/cmd/brew-upgrade-mysql
@@ -28,9 +28,7 @@ if [[ -d $(brew --prefix mysql@5.6) || -d $(brew --prefix mysql@5.7) ]]; then
     brew install mysql@5.7
   fi
 
-  if [[ -d $(brew --prefix mysql@5.7) ]]; then
-    brew services stop mysql@5.7 || true
-  fi
+  brew services stop mysql@5.7 || true
 
   update_my_cnf
 

--- a/cmd/brew-upgrade-mysql
+++ b/cmd/brew-upgrade-mysql
@@ -47,11 +47,9 @@ if [[ $MYSQL_5_6 == "0" || $MYSQL_5_7 == "0" ]]; then
 
   update_my_cnf
 
-  # Upgrade the MySQL tables
-  echo "Upgrading MySQL Tables ..."
   brew services start mysql@5.7
 
-  while ! nc -z localhost 3306; do
+  while ! $(brew --prefix mysql@5.7)/bin/mysqladmin ping --silent; do
     echo "Waiting for MySQL to be available..."
     sleep 2
   done

--- a/cmd/brew-upgrade-mysql
+++ b/cmd/brew-upgrade-mysql
@@ -43,7 +43,6 @@ if [[ -d $(brew --prefix mysql@5.6) || -d $(brew --prefix mysql@5.7) ]]; then
 
   $(brew --prefix mysql@5.7)/bin/mysql_upgrade -u root
   brew services restart mysql@5.7
-  brew services start mysql@5.7
 fi
 
 exit 0

--- a/cmd/brew-upgrade-mysql
+++ b/cmd/brew-upgrade-mysql
@@ -61,5 +61,4 @@ if [[ $MYSQL_5_6 == "0" || $MYSQL_5_7 == "0" ]]; then
   brew services start mysql@5.7
 fi
 
-EXPECTED_EXIT="1"
 exit 0


### PR DESCRIPTION
For our internal applications we need to move applications that use MySQL 5.6 to use 5.7.

This step follows the following logic from @ggunson 

> If mysql5.6 is installed:
>
> shutdown mysql
uninstall 5.6, install 5.7
modify the my.cnf file with new changes
start up mysql
run mysql_upgrade script
restart mysql

> If mysql5.7 is installed:
>
> shutdown mysql
modify the my.cnf file with the new changes
start up mysql
run mysql_upgrade script
restart mysql

Instead of modifying the `my.cnf` file I'm just backing up the existing one to `my.cnf.github` and replacing it with the following code

```
# For advice on how to change settings please see
# http://dev.mysql.com/doc/refman/5.7/en/server-configuration-defaults.html

[mysqld]

innodb_strict_mode=OFF
optimizer_switch='index_merge_intersection=OFF'
query_cache_size=0
sql_mode=NO_ENGINE_SUBSTITUTION
```

I'm sure I've botched up the scripting so any guidance would be 💯 