### PR TITLE
upgrade-mysql: don't die if mysql_upgrade has already been run

### DIFF
--- a/cmd/brew-upgrade-mysql
+++ b/cmd/brew-upgrade-mysql
@@ -2,6 +2,24 @@
 
 set -e
 
+mysql_upgrade() {
+  echo "Running mysql_upgrade..."
+
+  local exitstatus=0
+  # Hide failures from "already upgraded", otherwise let it bubble up
+  if ! output=$($(brew --prefix mysql@5.7)/bin/mysql_upgrade -u root); then
+    exitstatus="$?"
+    if echo "$output" | grep --quiet "already upgraded"; then
+      exitstatus=0
+    else
+      # If there's some other reason for this, we want to make sure it's heard
+      echo "$output"
+    fi
+  fi
+
+  return $exitstatus
+}
+
 update_my_cnf() {
   CNF_PATH="$(brew --prefix)/etc/my.cnf"
 
@@ -39,7 +57,8 @@ if [[ -d $(brew --prefix mysql@5.6) || -d $(brew --prefix mysql@5.7) ]]; then
     sleep 2
   done
 
-  $(brew --prefix mysql@5.7)/bin/mysql_upgrade -u root
+  mysql_upgrade
+
   brew services restart mysql@5.7
 fi
 


### PR DESCRIPTION
Ran into an issue where the `set +e` on `mysql_upgrade` caused the script to die from `mysql_upgrade` exiting 2 because my MySQL was already up to date. This silences the `mysql_upgrade` output and treats it as a success if it exits for that reason, otherwise it lets the failure bubble up.