### PR TITLE
mysql_upgrade part of bootstrap fixes

### DIFF
--- a/cmd/brew-upgrade-mysql
+++ b/cmd/brew-upgrade-mysql
@@ -41,51 +41,42 @@ sql_mode=NO_ENGINE_SUBSTITUTION
 EOM
 }
 
+mysql_stop() {
+  brew services stop $1 || true
+  while ! [[ "$(pgrep mysqld)" == "" ]]; do
+    echo "Waiting for MySQL to shut down ..." 
+    sleep 2
+  done
+}
+
+mysql_start() {
+  brew services start $1
+  while ! $(brew --prefix "$1")/bin/mysqladmin ping --silent; do
+    echo "Waiting for MySQL to be available..."
+    sleep 2
+  done
+}
 
 if [[ -d $(brew --prefix mysql@5.6) || -d $(brew --prefix mysql@5.7) ]]; then
   if [[ -d $(brew --prefix mysql@5.6) ]]; then
-    brew services stop mysql@5.6 || true
-
-    while ! [[ "$(pidof mysqld)" == "" ]]; do
-      echo "Waiting for MySQL to shut down ..."
-      sleep 2
-    done
+    mysql_stop "mysql@5.6"
 
     brew install mysql@5.7
   fi
 
-  brew services stop mysql@5.7 || true
-
-  while ! [[ "$(pidof mysqld)" == "" ]]; do
-    echo "Waiting for MySQL to shut down ..."
-    sleep 2
-  done
+  mysql_stop "mysql@5.7"
 
   update_my_cnf
 
-  brew services start mysql@5.7
+  mysql_start "mysql@5.7"
 
-  while ! $(brew --prefix mysql@5.7)/bin/mysqladmin ping --silent; do
-    echo "Waiting for MySQL to be available..."
-    sleep 2
-  done
 
-  upgrade_mysql
+  upgraded=$(upgrade_mysql)
 
-  # We need to give MySQL to shut down properly, let's not do a restart
-  brew services stop mysql@5.7
-
-  while ! [[ "$(pidof mysqld)" == "" ]]; do
-    echo "Waiting for MySQL to shut down ..."
-    sleep 2
-  done
-
-  brew services start mysql@5.7
-
-  while ! $(brew --prefix mysql@5.7)/bin/mysqladmin ping --silent; do
-    echo "Waiting for MySQL to be available..."
-    sleep 2
-  done
+  if [[ $upgraded -eq 0 ]]; then
+    mysql_stop "mysql@5.7"
+    mysql_start "mysql@5.7"
+  fi
 fi
 
 exit 0


### PR DESCRIPTION
The automated mysql upgrade in the bootstrap code has a few problems:

1. Uses `pidof` which doesn't exist in macos (see https://github.com/github/homebrew-bootstrap/pull/49#discussion_r162304758)
2. Restarts mysqld after running mysql_upgrade, whether or not an upgrade was run and it needs to.

So this code hopefully:

1. Uses `pgrep` instead of `pidof` to determine whether mysqld is running
2. Restarts mysqld only if mysql_upgrade actually ran an upgrade (exit code 0)
3. Made the stopping and starting of mysql into functions. 

Also, in https://github.com/github/homebrew-bootstrap/pull/47#issuecomment-357638694 @MikeMcQuaid asked for there to be a note in the README about this script when it was first created? I can put that in here too.

I'm not sure how to test this, though. Hoping someone can tell me?

/cc @tarebyte 
/cc @MikeMcQuaid @mistydemeo 
/cc @github/database-infrastructure 
/cc https://github.com/github/homebrew-bootstrap/pull/47 first PR for this code


