### PR TITLE
Add 2.4-typedruby definition

### DIFF
--- a/ruby-definitions/2.4-typedruby1
+++ b/ruby-definitions/2.4-typedruby1
@@ -1,0 +1,3 @@
+install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
+install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
+install_package "ruby-2_4_typedruby1" "https://github.com/github/ruby/archive/v2_4_typedruby1.tar.gz#c07d4f357123743467b9eb6809b597c28f7d315decddb31f682b20ca7c85d4f2" ldflags_dirs autoconf standard verify_openssl


### PR DESCRIPTION
Addition for local bootstrap of 2.4-typedruby

cc: @charliesome @gnawhleinad @MikeMcQuaid 