### PR TITLE
bootstrap-rbenv-ruby: respect RBENV_VERSION

### DIFF
--- a/cmd/brew-bootstrap-rbenv-ruby
+++ b/cmd/brew-bootstrap-rbenv-ruby
@@ -62,7 +62,11 @@ if ! which rbenv &>/dev/null; then
 fi
 
 if ! rbenv version-name &>/dev/null; then
-  RUBY_REQUESTED="$(rbenv local)"
+  if ! [[ -z "$RBENV_VERSION" ]]; then
+    RUBY_REQUESTED="$RBENV_VERSION"
+  else
+    RUBY_REQUESTED="$(rbenv local)"
+  fi
   RUBY_DEFINITION="$(ruby-build --definitions | grep "^$RUBY_REQUESTED$" || true)"
 
   if [ -z "$RUBY_DEFINITION" ]; then


### PR DESCRIPTION
This resolves an inconsistency which would occur if `RBENV_VERSION` was exported, and also makes it possible to use that environment variable to specify the Ruby version to install.

If `RBENV_VERSION` is exported, the `rbenv version-name` check will respect that environment variable; however, the `RUBY_REQUESTED` check was hardcoded to use `rbenv local`, which only considers `.ruby-version`. This improves that check by using `RBENV_VERSION` if specified, and falls back to `.ruby-version` if not; that behaviour matches the fallback preference used by `rbenv version-name`.