### PR TITLE
Ensure jq is installed

### DIFF
--- a/cmd/brew-upgrade-mysql
+++ b/cmd/brew-upgrade-mysql
@@ -23,7 +23,7 @@ install_mysql() {
   fi
 
   # In case jq is not installed
-  brew install jq &> /dev/null
+  brew list jq &>/dev/null || brew install jq
 
   # Upgrade to latest dot release
   current_version=$(brew info mysql --json=v1 | jq -r ".[] | .installed[].version")

--- a/cmd/brew-upgrade-mysql
+++ b/cmd/brew-upgrade-mysql
@@ -22,6 +22,9 @@ install_mysql() {
     brew install mysql@${mysql_version}
   fi
 
+  # In case jq is not installed
+  brew install jq &> /dev/null
+
   # Upgrade to latest dot release
   current_version=$(brew info mysql --json=v1 | jq -r ".[] | .installed[].version")
   latest_version=$(brew info mysql --json=v1 | jq -r ".[] | .versions.stable")


### PR DESCRIPTION
Seems that jq is not installed for everyone, so rather than putting that in a Brewfile on every repo that uses this, I'm manually installing this inside the script. If there is a better way, please let me know.

Note, https://github.com/github/github/blob/master/config/homebrew-bootstrap-version will need to be updated once this is merged.

cc: https://github.com/github/homebrew-bootstrap/issues/57