### PR TITLE
Use most recent version for "current" mysql version check.

### DIFF
--- a/cmd/brew-upgrade-mysql
+++ b/cmd/brew-upgrade-mysql
@@ -23,7 +23,7 @@ install_mysql() {
   fi
 
   # Upgrade to latest dot release
-  current_version=$(brew info mysql --json=v1 | jq -r ".[] | .installed[].version")
+  current_version=$(brew info mysql --json=v1 | jq -r ".[] | .installed[-1].version")
   latest_version=$(brew info mysql --json=v1 | jq -r ".[] | .versions.stable")
   if ! [ "${current_version}" = "${latest_version}" ]; then
     echo "Upgrading version of MySQL to ${latest_version}... "


### PR DESCRIPTION
On my system, every bootstrap was stopping and starting MySQL:

```
hettg@rhettbook ~/github/github (master) $ script/bootstrap
Ruby build 0d9762bcc5 is up-to-date.
Checking macOS Homebrew dependencies ...
The Brewfile's dependencies are satisfied.
Checking that MySQL is up to date.
Upgrading version of MySQL to 5.7.21...
Stopping `mysql`... (might take a while)
==> Successfully stopped `mysql` (label: homebrew.mxcl.mysql)
Waiting for MySQL to shut down.... done
Updating Homebrew...
Error: mysql@5.7 5.7.21 already installed
==> Successfully started `mysql` (label: homebrew.mxcl.mysql)
Waiting for MySQL to be available.... done
MySQL is ready.
Using Rails 3.2...
Git build 74d5b78aaf is up-to-date.
babeld build 9737740b31 is up-to-date.
codeload build 25db46ca76 is up-to-date.
dgit-update build 34aa20082c is up-to-date.
Building git-nw...
make: Nothing to be done for `binaries'.
Building node ...
Node 9.4.0 is up-to-date.
Building npm packages ...
Generating binstubs ...
Building robots.txt ...
Generating opensearch.xml ...
gpgverify build 5107d46e02 is up-to-date.
alambic build 643c0073f4 is up-to-date.
homebrew-bootstrap build 5bb3f6f384 is up-to-date.
lfs-server build d9cc0728b3 is up-to-date.
longpoll build 3d5260848d is up-to-date.
slumlord build d4e91f9b1e is up-to-date.
Checking that MySQL is up to date.
Upgrading version of MySQL to 5.7.21...
Stopping `mysql`... (might take a while)
==> Successfully stopped `mysql` (label: homebrew.mxcl.mysql)
Waiting for MySQL to shut down.... done
Error: mysql@5.7 5.7.21 already installed
==> Successfully started `mysql` (label: homebrew.mxcl.mysql)
Waiting for MySQL to be available.... done
MySQL is ready.
Already running under dotcom mode and the database is marked up-to-date.
To force a full fresh database and repository setup instead, use:
    script/setup --force
OK. The dotcom environment is ready.
================================================================================
All done! Your current environment: GitHub dotcom on Ruby 2.4.3-p200

WARNING: as you do not have '/Users/rhettg/github/github/bin' in your PATH
to avoid issues ensure you always run e.g. 'bin/rake' rather than just 'rake'.
```

I tracked this down the `jq` invocation. It turns out, I have multiple versions installed:

```
rhettg@rhettbook ~/github/github (master) $ brew info mysql --json=v1 | jq -r ".[] | .installed[].version"
5.7.20_1
5.7.21
```

I don't know if it matter that I have these both installed, but it sure does confuse this script. My change alters the check to only compare the most recent version installed to the current stable version.

This seems somewhat related to https://github.com/github/homebrew-bootstrap/pull/51/

/cc @github/database-infrastructure 
/cc @mistydemeo 