### PR TITLE
Fix brew-upgrade-mysql for latest changes

### DIFF
--- a/cmd/brew-upgrade-mysql
+++ b/cmd/brew-upgrade-mysql
@@ -12,7 +12,7 @@ set -e
 
 install_mysql() {
   current_mysql=$(brew list | grep -E "^mysql(@\\d\\.\\d)?$")
-  if ! [[ "${current_mysql}" == "mysql" || "${current_mysql}" == "mysql@${mysql_version}" ]]; then
+  if ! [[ "${current_mysql}" == "mysql@${mysql_version}" ]]; then
     if [ -n "${current_mysql}" ]; then
       echo "Uninstalling old version of MySQL... "
       brew services stop $current_mysql || true

--- a/cmd/brew-upgrade-mysql
+++ b/cmd/brew-upgrade-mysql
@@ -77,7 +77,7 @@ is_mysql_up() {
 }
 
 mysql_stop() {
-  brew services stop mysql || true
+  brew services stop mysql@5.7 || true
   echo -n "Waiting for MySQL to shut down..."
   while pgrep -q -f "${mysql_dir}.*mysqld"; do
     sleep 2
@@ -87,7 +87,7 @@ mysql_stop() {
 }
 
 mysql_restart() {
-  brew services restart mysql
+  brew services restart mysql@5.7
   echo -n "Waiting for MySQL to be available..."
   while ! is_mysql_up; do
     echo -n "."

--- a/cmd/brew-upgrade-mysql
+++ b/cmd/brew-upgrade-mysql
@@ -26,8 +26,8 @@ install_mysql() {
   brew list jq &>/dev/null || brew install jq
 
   # Upgrade to latest dot release
-  current_version=$(brew info mysql@5.7 --json=v1 | jq -r ".[] | .installed[-1].version")
-  latest_version=$(brew info mysql@5.7 --json=v1 | jq -r ".[] | .versions.stable")
+  current_version=$(brew info mysql@${mysql_version} --json=v1 | jq -r ".[] | .installed[-1].version")
+  latest_version=$(brew info mysql@${mysql_version} --json=v1 | jq -r ".[] | .versions.stable")
   if ! [ "${current_version}" = "${latest_version}" ]; then
     echo "Upgrading version of MySQL to ${latest_version}... "
     mysql_stop
@@ -77,7 +77,7 @@ is_mysql_up() {
 }
 
 mysql_stop() {
-  brew services stop mysql@5.7 || true
+  brew services stop mysql@${mysql_version} || true
   echo -n "Waiting for MySQL to shut down..."
   while pgrep -q -f "${mysql_dir}.*mysqld"; do
     sleep 2
@@ -87,7 +87,7 @@ mysql_stop() {
 }
 
 mysql_restart() {
-  brew services restart mysql@5.7
+  brew services restart mysql@${mysql_version}
   echo -n "Waiting for MySQL to be available..."
   while ! is_mysql_up; do
     echo -n "."

--- a/cmd/brew-upgrade-mysql
+++ b/cmd/brew-upgrade-mysql
@@ -26,8 +26,8 @@ install_mysql() {
   brew list jq &>/dev/null || brew install jq
 
   # Upgrade to latest dot release
-  current_version=$(brew info mysql --json=v1 | jq -r ".[] | .installed[-1].version")
-  latest_version=$(brew info mysql --json=v1 | jq -r ".[] | .versions.stable")
+  current_version=$(brew info mysql@5.7 --json=v1 | jq -r ".[] | .installed[-1].version")
+  latest_version=$(brew info mysql@5.7 --json=v1 | jq -r ".[] | .versions.stable")
   if ! [ "${current_version}" = "${latest_version}" ]; then
     echo "Upgrading version of MySQL to ${latest_version}... "
     mysql_stop


### PR DESCRIPTION
Homebrew has now shipped MySQL 8.0 as `mysql`, which has exposed a few bugs with the logic in this script. Namely:

* A few places start and stop `mysql` instead of `mysql@5.7`, assuming that they're equivalent, which they no longer are.
* The current/installed versions are looked up as `mysql` instead of `mysql@5.7`.
* We should no longer allow `mysql` to be considered the correct package.

I've tested, and this will safely migrate users to the versioned package.