### PR TITLE
upgrade-mysql: uninstall all obsolete MySQL packages

### DIFF
--- a/cmd/brew-upgrade-mysql
+++ b/cmd/brew-upgrade-mysql
@@ -16,7 +16,7 @@ install_mysql() {
     if [ -n "${current_mysql}" ]; then
       echo "Uninstalling old version of MySQL... "
       brew services stop $current_mysql || true
-      brew uninstall $current_mysql
+      brew uninstall --force $current_mysql
     fi
     echo "Installing new version of MySQL... "
     brew install mysql@${mysql_version}


### PR DESCRIPTION
I realized that this will fail if the user has multiple versions of `mysql` installed; this will happen if the user had `brew upgrade`d a few times without ever running `brew cleanup`. For example:

```
Uninstalling old version of MySQL... 
Error: mysql has multiple installed versions
```