### PR TITLE
Add zulu8

### DIFF
--- a/Casks/zulu8.rb
+++ b/Casks/zulu8.rb
@@ -1,0 +1,33 @@
+cask 'zulu8' do
+  version '1.8.0_181,8.31.0.1'
+  sha256 '54fe3a1b9e636c8f45f313eb4084cda336341806a29b188d39eccddfc522b25f'
+
+  url "https://cdn.azul.com/zulu/bin/zulu#{version.after_comma}-jdk#{version.minor}.#{version.patch}.#{version.before_comma.sub(%r{.*_}, '')}-macosx_x64.dmg",
+      referer: 'https://www.azul.com/downloads/zulu/zulu-mac/'
+  name 'Azul Zulu Java Standard Edition Development Kit'
+  homepage 'https://www.azul.com/downloads/zulu/zulu-mac/'
+
+  pkg "Double-Click to Install Zulu #{version.minor}.pkg"
+
+  postflight do
+    system_command '/bin/mv',
+                   args: ['-f', '--', "/Library/Java/JavaVirtualMachines/zulu-#{version.minor}.jdk", "/Library/Java/JavaVirtualMachines/zulu#{version.before_comma}.jdk"],
+                   sudo: true
+    system_command '/bin/ln',
+                   args: ['-nsf', '--', "/Library/Java/JavaVirtualMachines/zulu#{version.before_comma}.jdk", "/Library/Java/JavaVirtualMachines/zulu-#{version.minor}.jdk"],
+                   sudo: true
+    system_command '/bin/ln',
+                   args: ['-nsf', '--', "/Library/Java/JavaVirtualMachines/zulu#{version.before_comma}.jdk/Contents/Home", '/Library/Java/Home'],
+                   sudo: true
+    system_command '/usr/libexec/PlistBuddy',
+                   args: ['-c', 'Add :JavaVM:JVMCapabilities: string JNI', "/Library/Java/JavaVirtualMachines/zulu#{version.before_comma}.jdk/Contents/Info.plist"],
+                   sudo: true
+  end
+
+  uninstall pkgutil: "com.azulsystems.zulu.#{version.minor}",
+            delete:  [
+                       "/Library/Java/JavaVirtualMachines/zulu#{version.before_comma}.jdk",
+                       "/Library/Java/JavaVirtualMachines/zulu-#{version.minor}.jdk",
+                       '/Library/Java/Home',
+                     ]
+end

--- a/cmd/brew-bootstrap-jenv-java
+++ b/cmd/brew-bootstrap-jenv-java
@@ -75,8 +75,8 @@ tap "github/bootstrap"
 cask "$cask_name"
 EOS
 
-  zulu_version_string="$(echo $JAVA_REQUESTED | sed 's,\(.*\)\.,\1_,')"
-  yes | jenv add "/Library/Java/JavaVirtualMachines/zulu${zulu_version_string}.jdk/Contents/Home"
+  java_home=$(/usr/libexec/java_home -v $JAVA_REQUESTED)
+  yes | jenv add $java_home
 fi
 
 if [ "$(jenv exec java -version 2>&1)" != "$(java -version 2>&1)" ]; then

--- a/cmd/brew-bootstrap-jenv-java
+++ b/cmd/brew-bootstrap-jenv-java
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Installs Java.
+# Installs Zulu JDK.
 set -e
 
 if [ "$1" = "--debug" ]; then
@@ -57,7 +57,7 @@ trap "cleanup" EXIT
 
 BASE_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
-if ! which rbenv &>/dev/null; then
+if ! which jenv &>/dev/null; then
   abort "Error: you need to 'brew install jenv'!"
 fi
 

--- a/cmd/brew-bootstrap-jenv-java
+++ b/cmd/brew-bootstrap-jenv-java
@@ -1,0 +1,87 @@
+#!/bin/bash
+# Installs Java.
+set -e
+
+if [ "$1" = "--debug" ]; then
+  shift
+  PRINT_DEBUG="1"
+  set -x
+fi
+
+warn() { echo "$@" >&2; }
+abort() { EXPECTED_EXIT="1"; warn "$@"; exit 1; }
+
+abort_for_sh() {
+  abort 'Error: add `eval "$(jenv init -)"` to the end of your .bash_profile!'
+}
+
+abort_for_zsh() {
+  abort 'Error: add `eval "$(jenv init -)"` to the end of your .zshrc!'
+}
+
+abort_for_fish() {
+  abort 'Error: check the installation instructions at https://github.com/gcuisinier/jenv#gettings-started!'
+}
+
+abort_with_shell_setup_message() {
+  case $(basename ${SHELL:-bash}) in
+  sh|bash)
+    abort_for_sh
+    ;;
+  zsh)
+    abort_for_zsh
+    ;;
+  fish)
+    abort_for_fish
+    ;;
+  # tcsh users are on their own
+  *)
+    abort 'Error: you must finish setting up jenv in your shell; check `jenv init` for instructions!'
+  esac
+}
+
+cleanup() {
+  set +e
+  if [ -n "$EXPECTED_EXIT" ]; then
+    return
+  fi
+  warn "Error: $(basename $0) failed!"
+  if [ -z "$PRINT_DEBUG" ]; then
+    warn "For debugging output run:"
+    warn "  $0 --debug"
+    warn "If you're stuck: file an issue with debugging output at:"
+    warn "  https://github.com/github/homebrew-bootstrap/issues/new"
+  fi
+}
+trap "cleanup" EXIT
+
+BASE_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+if ! which rbenv &>/dev/null; then
+  abort "Error: you need to 'brew install jenv'!"
+fi
+
+if ! jenv version-name &>/dev/null; then
+  if ! [[ -z "$JENV_VERSION" ]]; then
+    JAVA_REQUESTED="$JENV_VERSION"
+  else
+    JAVA_REQUESTED="$(jenv local)"
+  fi
+
+  cask_version="$(echo $JAVA_REQUESTED | awk -F. '{ print $2 }')"
+  cask_name="github/bootstrap/zulu${cask_version}"
+  brew bundle --file=- <<-EOS
+tap "github/bootstrap"
+cask "$cask_name"
+EOS
+
+  zulu_version_string="$(echo $JAVA_REQUESTED | sed 's,\(.*\)\.,\1_,')"
+  yes | jenv add "/Library/Java/JavaVirtualMachines/zulu${zulu_version_string}.jdk/Contents/Home"
+fi
+
+if [ "$(jenv exec java -version 2>&1)" != "$(java -version 2>&1)" ]; then
+  abort_with_shell_setup_message
+fi
+
+EXPECTED_EXIT="1"
+exit 0


### PR DESCRIPTION
This imports a `zulu8` package. To start, I've just copied the existing upstream Homebrew cask package; if we need customizations, we can do whatever we want. After running `brew cask install homebrew/bootstrap/zulu8`, everything looks fine, and this Java version seems to be working properly.