### PR TITLE
brew-upgrade-mysql: limit table_open_cache

### DIFF
--- a/cmd/brew-upgrade-mysql
+++ b/cmd/brew-upgrade-mysql
@@ -62,6 +62,7 @@ innodb_strict_mode=OFF
 optimizer_switch='index_merge_intersection=OFF'
 query_cache_size=0
 sql_mode=NO_ENGINE_SUBSTITUTION
+table_open_cache=100
 EOM
 
 if ! diff -q "$CNF_PATH" "$TMP_PATH"; then


### PR DESCRIPTION
When using MySQL 5.7 and older on macOS, select(2) is used, which limits the number of file descriptors that can be used to FD_SETSIZE (1024). Unfortunately, MySQL is not very good at limiting its use of file descriptors, and it will happily use all of them on caches, preventing connections to the database for queries.

Since this is not a very useful state to be in, limit the number of files used for caching open descriptors to 100. This should be fine for a typical development environment, and ensures that sufficient connections can be made for queries to execute.