### PR TITLE
bootstrap-rbenv-ruby: install older Bundler on < 2.3

### DIFF
--- a/cmd/brew-bootstrap-rbenv-ruby
+++ b/cmd/brew-bootstrap-rbenv-ruby
@@ -89,7 +89,14 @@ if [ "$(rbenv exec ruby --version)" != "$(ruby --version)" ]; then
 fi
 
 (rbenv which bundle &>/dev/null && bundle -v &>/dev/null) || {
-  gem install bundler
+  # Bundler 2 doesn't support Ruby 2.x or below, but
+  # Rubygems won't automatically pick a compatible Bundler for us. Boo!
+  if [[ "$RUBY_REQUESTED" < "2.3" ]]; then
+    gem install bundler -v '<2'
+  else
+    gem install bundler
+  fi
+
   rbenv rehash
 }
 


### PR DESCRIPTION
As noted in #68, Bundler 2 doesn't install on Ruby versions below 2.3. We should detect that case and install a compatible bundler when appropriate.

Fixes #68.