### PR TITLE
upgrade-mysql: fix when MySQL is not installed

### DIFF
--- a/cmd/brew-upgrade-mysql
+++ b/cmd/brew-upgrade-mysql
@@ -11,7 +11,8 @@
 set -e
 
 install_mysql() {
-  current_mysql=$(brew list | grep -E "^mysql(@\\d\\.\\d)?$")
+  current_mysql=$(brew list | grep -E "^mysql(@\\d\\.\\d)?$") || true
+
   if ! [[ "${current_mysql}" == "mysql@${mysql_version}" ]]; then
     if [ -n "${current_mysql}" ]; then
       echo "Uninstalling old version of MySQL... "


### PR DESCRIPTION
I noticed an issue where this script bails out early in the process if MySQL isn't installed at all. The expected behaviour is that it should go ahead and install it if it's not present.
The problem is in `install_mysql`; the `grep` in the assignment to `current_mysql` would exit 1 if no `mysql` package is installed, and because the script is run `set -e`, the entire script would bail out. This change allows the function to continue even if `grep` finds nothing.