### PR TITLE
brew-setup-nginx-conf: use `brew cleanup --prune`.

### DIFF
--- a/cmd/brew-setup-nginx-conf.rb
+++ b/cmd/brew-setup-nginx-conf.rb
@@ -3,19 +3,6 @@
 require "erb"
 require "pathname"
 
-# Prunes invalid symlinks; an invalid project can lead
-# to dangling symlinks in the Nginx root, which need
-# to be removed.
-def prune_dangling_symlinks_from prefix
-  base = Pathname.new(prefix)
-  base.children.select(&:symlink?).each do |symlink|
-    if !symlink.realpath.exist?
-      puts "Deleting invalid symlink: #{symlink}"
-      symlink.unlink
-    end
-  end
-end
-
 root_configuration = ARGV.delete "--root"
 if root_configuration
   http_port = 80
@@ -128,7 +115,7 @@ unless system "ln -sf '#{File.absolute_path(output)}' '#{server}'"
   abort "Error: failed to symlink #{output} to #{server}!"
 end
 
-prune_dangling_symlinks_from server_base_path
+system "brew cleanup --prune >/dev/null"
 
 unless started_services
   unless system "brew services restart nginx >/dev/null"


### PR DESCRIPTION
This was re-added as an alternative to the old `brew prune` on popular demand.