### PR TITLE
Change the default timezone to UTC

### DIFF
--- a/cmd/brew-upgrade-mysql
+++ b/cmd/brew-upgrade-mysql
@@ -64,6 +64,7 @@ optimizer_switch='index_merge_intersection=OFF'
 query_cache_size=0
 sql_mode=NO_ENGINE_SUBSTITUTION
 table_open_cache=100
+default-time-zone='+00:00'
 EOM
 
 if ! diff -q "$CNF_PATH" "$TMP_PATH"; then


### PR DESCRIPTION
This reduces the number of non-UTC tz dependent time conversions which should make local development much closer to how the actual server runs. Also, UTC conversions are much faster (up to 7X faster) than time zone dependent conversions.

```ruby
Benchmark.ips do |x|
  x.report "at" do |times|
    Time.at(1)
  end

  x.report "local" do |times|
    Time.local(2001, 1, 1, 1, 1, 1, 1)
  end

  x.report "utc" do |times|
    Time.utc(2001, 1, 1, 1, 1, 1, 1)
  end

  x.compare!
end
```

Results in:

```shell
$ ruby script/benchmark
Warming up --------------------------------------
                  at   225.583k i/100ms
               local    24.474k i/100ms
                 utc    57.434k i/100ms
Calculating -------------------------------------
                  at    221.967B (±10.8%) i/s -    507.901B
               local      6.326B (±17.7%) i/s -     27.582B in   4.738513s
                 utc     41.447B (±35.5%) i/s -    146.765B

Comparison:
                  at: 221966772987.2 i/s
                 utc: 41446699159.0 i/s - 5.36x  slower
               local: 6325793112.5 i/s - 35.09x  slower
```