### PR TITLE
Add Hive@2 and Hadoop@2 formulas

### DIFF
--- a/Formula/kind.rb
+++ b/Formula/kind.rb
@@ -1,0 +1,17 @@
+class Kind < Formula
+  desc "Kubernetes IN Docker - local clusters for testing Kubernetes"
+  homepage "https://kind.sigs.k8s.io/"
+  url "https://github.com/kubernetes-sigs/kind/archive/v0.3.0.tar.gz"
+  sha256 "3d62392919bd93421acf61a17502f9dab8ec8d2a792b342b7a1abd749dbf81ef"
+
+  depends_on "docker" => :build
+
+  def install
+    bin.mkpath
+    system "make", "INSTALL_DIR=#{bin}", "install"
+  end
+
+  test do
+    assert_equal "kind version v#{version}", shell_output("#{bin}/kind --version").chomp
+  end
+end


### PR DESCRIPTION
This PR adds Hive@2 and Hadoop@2 formulas to be able to setup our local development environment on Mac OS X as we need to interact with Hive 2.3.2.

/cc @github/data-engineering 

