### PR TITLE
Update the mysql version check to use `brew outdated`.

### DIFF
--- a/cmd/brew-upgrade-mysql
+++ b/cmd/brew-upgrade-mysql
@@ -27,12 +27,10 @@ install_mysql() {
   brew list jq &>/dev/null || brew install jq
 
   # Upgrade to latest dot release
-  current_version=$(brew info mysql@${mysql_version} --json=v1 | jq -r ".[] | .installed[-1].version")
-  latest_version=$(brew info mysql@${mysql_version} --json=v1 | jq -r ".[] | .versions.stable")
-  if ! [ "${current_version}" = "${latest_version}" ]; then
-    echo "Upgrading version of MySQL to ${latest_version}... "
+  if ! brew outdated mysql@${mysql_version}; then
+    echo "Upgrading version of MySQL... "
     mysql_stop
-    brew upgrade mysql@${mysql_version} || true
+    brew upgrade mysql@${mysql_version} || echo "Check for or open an issue on https://github.com/github/homebrew-bootstrap/issues"
   fi
 
   if ! is_mysql_up; then

--- a/cmd/brew-upgrade-mysql
+++ b/cmd/brew-upgrade-mysql
@@ -62,6 +62,11 @@ optimizer_switch='index_merge_intersection=OFF'
 query_cache_size=0
 sql_mode=NO_ENGINE_SUBSTITUTION
 table_open_cache=100
+gtid_mode=ON
+enforce_gtid_consistency=ON
+server_id=1
+log_bin=mysql-bin.log
+expire_logs_days=1
 EOM
 
 if ! diff -q "$CNF_PATH" "$TMP_PATH"; then

--- a/cmd/brew-upgrade-mysql
+++ b/cmd/brew-upgrade-mysql
@@ -27,7 +27,7 @@ install_mysql() {
   brew list jq &>/dev/null || brew install jq
 
   # Upgrade to latest dot release
-  if ! brew outdated mysql@${mysql_version}; then
+  if [ -n "$(brew outdated mysql@${mysql_version})" ]; then
     echo "Upgrading version of MySQL... "
     mysql_stop
     brew upgrade mysql@${mysql_version} || echo "Check for or open an issue on https://github.com/github/homebrew-bootstrap/issues"


### PR DESCRIPTION
There was a new revision of mysql@5.7 built which added an `_1` to the mysql version number. Because of this everytime someone used the brew-upgrade-mysql script, it would attempt to unnecessarily upgrade mysql. This change fixes that logic that caused this.

fixes: https://github.com/github/homebrew-bootstrap/issues/81
cc: @github/database-infrastructure