### PR TITLE
Use homebrew revision when checking mysql version

### DIFF
--- a/cmd/brew-upgrade-mysql
+++ b/cmd/brew-upgrade-mysql
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # brew-upgrade-mysql: Tool to upgrade MySQL version used by GitHub prod
 #
@@ -29,6 +29,8 @@ install_mysql() {
   # Upgrade to latest dot release
   current_version=$(brew info mysql@${mysql_version} --json=v1 | jq -r ".[] | .installed[-1].version")
   latest_version=$(brew info mysql@${mysql_version} --json=v1 | jq -r ".[] | .versions.stable")
+  latest_revision=$(brew info mysql@${mysql_version} --json=v1 | jq -r ".[] | .revision")
+  [[ $latest_revision -gt "0" ]] && latest_version="${latest_version}_$latest_revision"
   if ! [ "${current_version}" = "${latest_version}" ]; then
     echo "Upgrading version of MySQL to ${latest_version}... "
     mysql_stop


### PR DESCRIPTION
When the mysql homebrew formula has a [revision](https://docs.brew.sh/Formula-Cookbook#formulae-revisions), the current `cmd/brew-upgrade-mysql` tries to reinstall it because it thinks the version doesn't match. For example, the current latest version of `mysql@5.7` is `5.7.27` but the revision is `1` so the value of `.installed[-1].version` is `5.7.27_1`, resulting in the following:

```sh
Checking that MySQL is up to date.
Upgrading version of MySQL to 5.7.27...
Stopping `mysql@5.7`... (might take a while)
==> Successfully stopped `mysql@5.7` (label: homebrew.mxcl.mysql@5.7)
Waiting for MySQL to shut down.... done
Error: mysql@5.7 5.7.27_1 already installed
==> Successfully started `mysql@5.7` (label: homebrew.mxcl.mysql@5.7)
Waiting for MySQL to be available.... done
MySQL is ready.
```

This change will use the revision during the version check if it's greater than zero.

Unrelated, it also updates the script path to be POSIX compliant.