### PR TITLE
Allow people to not use Rbenv if they decide

### DIFF
--- a/cmd/brew-bootstrap-rbenv-ruby
+++ b/cmd/brew-bootstrap-rbenv-ruby
@@ -2,6 +2,12 @@
 # Installs Ruby and Bundler.
 set -e
 
+if ! [[ -z "$DONT_USE_RBENV" ]]; then
+  echo "Skipping rbenv bootstrap because DONT_USE_RBENV is set."
+  echo "Make sure you handle ruby installation and selection yourself before running bootstrap."
+  exit 0
+fi
+
 if [ "$1" = "--debug" ]; then
   shift
   PRINT_DEBUG="1"


### PR DESCRIPTION
I use chruby to manage rubies locally. This is known to conflict with rbenv.
This env var gives me a way to bail on this script and manage my own rubies.

cc @MikeMcQuaid 