### PR TITLE
bootstrap-rbenv-ruby: stop using Homebrew openssl

### DIFF
--- a/cmd/brew-bootstrap-rbenv-ruby
+++ b/cmd/brew-bootstrap-rbenv-ruby
@@ -78,9 +78,6 @@ if ! rbenv version-name &>/dev/null; then
     fi
   fi
 
-  HOMEBREW_PREFIX="$(brew --prefix)"
-  export RUBY_CONFIGURE_OPTS="--with-openssl-dir=$HOMEBREW_PREFIX/opt/openssl"
-
   rbenv install --skip-existing "$RUBY_DEFINITION"
 fi
 


### PR DESCRIPTION
ruby-build itself has workarounds for OpenSSL now, and with potentially multiple versions needed this workaround doesn't always work. We have better solutions now.