### PR TITLE
brew-upgrade-mysql: Fix `brew list` deprecation

### DIFF
--- a/cmd/brew-upgrade-mysql
+++ b/cmd/brew-upgrade-mysql
@@ -11,7 +11,7 @@
 set -e
 
 install_mysql() {
-  current_mysql=$(brew list | grep -E "^mysql(@\\d\\.\\d)?$") || true
+  current_mysql=$(brew list --formula | grep -E "^mysql(@\\d\\.\\d)?$") || true
 
   if ! [[ "${current_mysql}" == "mysql@${mysql_version}" ]]; then
     if [ -n "${current_mysql}" ]; then
@@ -24,7 +24,7 @@ install_mysql() {
   fi
 
   # In case jq is not installed
-  brew list jq &>/dev/null || brew install jq
+  brew list --formula jq &>/dev/null || brew install jq
 
   # Upgrade to latest dot release
   if [ -n "$(brew outdated mysql@${mysql_version})" ]; then


### PR DESCRIPTION
- This was reporting: `Warning: Calling `brew list` to only list formulae is deprecated! Use `brew list --formula` instead.`.

- I originally saw this in github/github `./script/bootstrap` output and tracked it down to here. I don't know how to make `github/github` know that this has changed, but I know from experience that this will fix the error message once it has the newer version.

Before:

```shell
issyl0 at cetus in /usr/local/Homebrew/Library/Taps/github/homebrew-bootstrap on master
❯ brew upgrade-mysql
Checking that MySQL is up to date.
Error: Calling `brew list` to only list formulae is deprecated! Use `brew list --formula` instead.
Installing new version of MySQL...
Warning: mysql@5.7 5.7.32 is already installed and up-to-date
To reinstall 5.7.32, run `brew reinstall mysql@5.7`
MySQL is ready.
```

After:

```shell
issyl0 at cetus in /usr/local/Homebrew/Library/Taps/github/homebrew-bootstrap on fix-brew-list-deprecation
❯ brew upgrade-mysql
Checking that MySQL is up to date.
MySQL is ready.
```
