### PR TITLE
Use openjdk@8

### DIFF
--- a/Formula/elasticsearch@1.7.rb
+++ b/Formula/elasticsearch@1.7.rb
@@ -9,7 +9,7 @@ class ElasticsearchAT17 < Formula
 
   keg_only :versioned_formula
 
-  depends_on :java => "1.7+"
+  depends_on "openjdk@8"
 
   def cluster_name
     "elasticsearch_#{ENV["USER"]}"

--- a/Formula/elasticsearch@2.4.rb
+++ b/Formula/elasticsearch@2.4.rb
@@ -9,7 +9,7 @@ class ElasticsearchAT24 < Formula
 
   keg_only :versioned_formula
 
-  depends_on :java => "1.8"
+  depends_on "openjdk@8"
 
   def cluster_name
     "elasticsearch_#{ENV["USER"]}"

--- a/Formula/hadoop@2.rb
+++ b/Formula/hadoop@2.rb
@@ -7,7 +7,7 @@ class HadoopAT2 < Formula
 
   bottle :unneeded
 
-  depends_on :java => "1.7+"
+  depends_on "openjdk@8"
 
   def install
     rm_f Dir["bin/*.cmd", "sbin/*.cmd", "libexec/*.cmd", "etc/hadoop/*.cmd"]

--- a/Formula/hive@2.rb
+++ b/Formula/hive@2.rb
@@ -7,7 +7,7 @@ class HiveAT2 < Formula
   bottle :unneeded
 
   depends_on "hadoop@2"
-  depends_on :java => "1.7+"
+  depends_on "openjdk@8"
 
   def install
     rm_f Dir["bin/*.cmd", "bin/ext/*.cmd", "bin/ext/util/*.cmd"]


### PR DESCRIPTION
`depends_on :java` was deprecated in https://github.com/Homebrew/brew/pull/9209.

Ran `brew install` and `brew test` for these all locally and they worked as expected.

