### PR TITLE
Update logs to reflect new launchdns default TLD

### DIFF
--- a/cmd/brew-setup-nginx-conf.rb
+++ b/cmd/brew-setup-nginx-conf.rb
@@ -70,9 +70,9 @@ EOS
 
 started_services = false
 unless system "echo '#{brewfile}' | brew bundle check --file=- >/dev/null"
-  puts "Installing *.dev dependencies:"
+  puts "Installing *.localhost dependencies:"
   unless system "echo '#{brewfile}' | brew bundle --file=-"
-    abort "Error: install *.dev dependencies with brew bundle!"
+    abort "Error: install *.localhost dependencies with brew bundle!"
   end
   started_services = true
 end


### PR DESCRIPTION
The launchdns brew install changed the default resolver from .dev to .localhost, so this updates the log messages around installing it to reflect that

Homebrew/homebrew-core#18365

Homebrew/homebrew-core@9203fb7