### PR TITLE
Fix --help flag usage

### DIFF
--- a/cmd/brew-bootstrap-jenv-java
+++ b/cmd/brew-bootstrap-jenv-java
@@ -1,5 +1,7 @@
 #!/bin/bash
-# Installs Zulu JDK.
+#:  `Usage: brew bootstrap-jenv-java` [--debug]
+#:
+#:  Installs Zulu JDK.
 set -e
 
 if [ "$1" = "--debug" ]; then

--- a/cmd/brew-bootstrap-nodenv-node
+++ b/cmd/brew-bootstrap-nodenv-node
@@ -1,5 +1,7 @@
 #!/bin/bash
-# Installs Node and NPM.
+#:  `Usage: brew bootstrap-nodenv-node` [--debug]
+#:
+#:  Installs Node and NPM.
 set -e
 
 if [ "$1" = "--debug" ]; then

--- a/cmd/brew-bootstrap-rbenv-ruby
+++ b/cmd/brew-bootstrap-rbenv-ruby
@@ -1,5 +1,7 @@
 #!/bin/bash
-# Installs Ruby and Bundler.
+#:  `Usage: brew bootstrap-rbenv-ruby` [--debug]
+#:
+#:  Installs Ruby and Bundler.
 set -e
 
 if [ "$1" = "--debug" ]; then

--- a/cmd/brew-report-issue.rb
+++ b/cmd/brew-report-issue.rb
@@ -1,7 +1,9 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-# Creates and closes failure debugging issues on a project.
+#:  `Usage: brew report-issue` [--close] <user/repo> <message> [<STDIN piped body>]
+#:
+#:  Creates and closes failure debugging issues on a project.
 close = !ARGV.delete("--close").nil?
 user_repo = ARGV.shift
 message = ARGV.shift

--- a/cmd/brew-setup-nginx-conf.rb
+++ b/cmd/brew-setup-nginx-conf.rb
@@ -39,7 +39,7 @@ ARGV.delete_if do |argument|
   true
 end
 
-data = IO.read input
+data = File.read input
 conf = ERB.new(data).result(variables)
 output = input.sub(/.erb$/, "")
 output.sub!(/.conf$/, ".root.conf") if root_configuration
@@ -82,20 +82,20 @@ end
 
 if `readlink /etc/resolver 2>/dev/null`.chomp != "/usr/local/etc/resolver"
   puts "Asking for your password to setup *.dev:" unless system "sudo -n true >/dev/null"
-  system "sudo rm -rf /etc/resolver"
-  unless system "sudo ln -sf /usr/local/etc/resolver /etc/resolver"
+  system "sudo", "rm", "-rf", "/etc/resolver"
+  unless system "sudo", "ln", "-sf", "/usr/local/etc/resolver", "/etc/resolver"
     abort "Error: failed to symlink /usr/local/etc/resolver to /etc/resolver!"
   end
 end
 
 if File.exist? "/etc/pf.anchors/dev.strap"
   puts "Asking for your password to uninstall pf:" unless system "sudo -n true >/dev/null"
-  system "sudo rm /etc/pf.anchors/dev.strap"
+  system "sudo", "rm", "/etc/pf.anchors/dev.strap"
   system "sudo grep -v 'dev.strap' /etc/pf.conf | sudo tee /etc/pf.conf"
   system "sudo launchctl unload /Library/LaunchDaemons/dev.strap.pf.plist 2>/dev/null"
   system "sudo launchctl load -w /Library/LaunchDaemons/dev.strap.pf.plist 2>/dev/null"
   system "sudo launchctl unload /Library/LaunchDaemons/dev.strap.pf.plist 2>/dev/null"
-  system "sudo rm -f /Library/LaunchDaemons/dev.strap.pf.plist"
+  system "sudo", "rm", "-f", "/Library/LaunchDaemons/dev.strap.pf.plist"
 end
 launch_socket_server_info = `brew services list | grep launch_socket_server | grep started`.chomp
 if launch_socket_server_info != ""

--- a/cmd/brew-setup-nginx-conf.rb
+++ b/cmd/brew-setup-nginx-conf.rb
@@ -1,7 +1,10 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-# Generates and installs a project nginx configuration using erb.
+#:  `Usage: brew setup-nginx-conf` [--root] [--extra-val=variable=value]
+#:                               <project_name> <project_root_path> <nginx.conf.erb>
+#:
+#:  Generates and installs a project `nginx` configuration using `erb`.
 require "erb"
 require "pathname"
 

--- a/cmd/brew-upgrade-mysql
+++ b/cmd/brew-upgrade-mysql
@@ -1,12 +1,12 @@
 #!/bin/bash
 #
-# brew-upgrade-mysql: Tool to upgrade MySQL version used by GitHub prod
-#
-# * Upgrades from MySQL 5.6 to 5.7
-# * Upgrades 5.7 to latest dot release
-# * Verifies that `mysql_upgrade` has run to update all system schemas
-# * Updates my.cnf to match the my.cnf (maintained in this script.)
-#
+#:  `Usage: brew-upgrade-mysql`
+#:
+#:  Upgrade `mysql` version used by GitHub production.
+#:
+#:  Upgrades from `mysql` 5.6 to 5.7, upgrades 5.7 to latest patch release, verifies
+#:  that `mysql_upgrade` has run to update all system schemas, updates `my.cnf`
+#:  to match the `my.cnf` maintained in this script.
 
 set -e
 

--- a/cmd/brew-vendor-gem
+++ b/cmd/brew-vendor-gem
@@ -1,10 +1,13 @@
 #!/bin/bash
-#/ Usage: brew vendor-gem [-r <rev>] [-n <gem>] <git-url>
-#/ Build a gem for the given git repository and stick it in vendor/cache. With -r, build
-#/ the gem at the branch, tag, or SHA1 given. With no -r, build the default HEAD.
-#/
-#/ This command is used in situations where you'd typically use a :git bundler
-#/ source, but allows for caching in vendor.
+
+#:  `Usage: brew vendor-gem` [-r <rev>] [-n <gem>] <git-url>
+#:
+#:  Build a gem for the given git repository and stick it in vendor/cache. With -r, build
+#:  the gem at the branch, tag, or SHA1 given. With no -r, build the default
+#:  HEAD.
+#:
+#:  This command is used in situations where you'd typically use a :git bundler
+#:  source, but allows for caching in vendor.
 set -e
 [ $# -eq 0 ] && set -- --help
 
@@ -21,7 +24,7 @@ while [ $# -gt 0 ]; do
                         shift 2
                         ;;
                 -h|--help)
-                        grep ^#/ <"$0" |cut -c4-
+                        grep ^#: <"$0" |cut -c5-
                         exit
                         ;;
                 *)


### PR DESCRIPTION
`brew --help` will read from `#:` formatted strings so add/fix these to improve the built-in documentation.