### PR TITLE
[Codespaces] Don't fail if VS Code is already installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A series of helper scripts, casks and formulae to reduce duplication across `scr
 - [`brew bootstrap-jenv-java`](cmd/brew-bootstrap-jenv-java): Installs Zulu JDK.
 - [`brew bootstrap-nodenv-node`](cmd/brew-bootstrap-nodenv-node): Installs Node and NPM.
 - [`brew bootstrap-rbenv-ruby`](cmd/brew-bootstrap-rbenv-ruby): Installs Ruby and Bundler.
-- [`brew macos-vscode-codespaces`](cmd/macos-vscode-codespaces): Get Visual Studio Code ready for running with Codespaces.
+- [`brew macos-vscode-codespaces`](cmd/brew-macos-vscode-codespaces): Get Visual Studio Code ready for running with Codespaces.
 - [`brew report-issue`](cmd/brew-report-issue.rb): Creates and closes failure debugging issues on a project.
 - [`brew setup-nginx-conf`](cmd/brew-setup-nginx-conf.rb): Generates and installs a project `nginx` configuration using `erb`.
 - [`brew upgrade-mysql`](cmd/brew-upgrade-mysql): Upgrade `mysql` version used by GitHub production.

--- a/cmd/brew-macos-vscode-codespaces
+++ b/cmd/brew-macos-vscode-codespaces
@@ -29,10 +29,11 @@ if [ "$(readlink /etc/resolver)" != "/usr/local/etc/resolver" ] ||
 fi
 
 # Install launchdns and VS Code.
-brew bundle --quiet --file=- <<RUBY
+(brew bundle --quiet --file=- <<RUBY
 brew "launchdns", restart_service: true
 cask "visual-studio-code"
 RUBY
+) || true
 
 # Stop nginx (if it is already running).
 if launchctl list | grep -q nginx; then

--- a/cmd/brew-macos-vscode-codespaces
+++ b/cmd/brew-macos-vscode-codespaces
@@ -29,11 +29,10 @@ if [ "$(readlink /etc/resolver)" != "/usr/local/etc/resolver" ] ||
 fi
 
 # Install launchdns and VS Code.
-(brew bundle --quiet --file=- <<RUBY
+brew bundle --quiet --file=- <<RUBY
 brew "launchdns", restart_service: true
-cask "visual-studio-code"
+cask "visual-studio-code" unless File.exist?("/Applications/Visual Studio Code.app")
 RUBY
-) || true
 
 # Stop nginx (if it is already running).
 if launchctl list | grep -q nginx; then


### PR DESCRIPTION
As [reported in Slack](https://github.slack.com/archives/C01S7MANE30/p1621283162156700?thread_ts=1621281287.152600&cid=C01S7MANE30)

Currently the script fails if VS Code is already installed:

```
❯ brew macos-vscode-codespaces
Using launchdns
==> Downloading https://update.code.visualstudio.com/1.56.2/darwin/stable
==> Downloading from https://az764295.vo.msecnd.net/stable/054a9295330880ed74ceaedda236253b4f39a335/VSCode-darwin.zip
==> Installing Cask visual-studio-code
Error: It seems there is already an App at '/Applications/Visual Studio Code.app'.
==> Purging files for version 1.56.2 of Cask visual-studio-code
Installing visual-studio-code has failed!
Homebrew Bundle failed! 1 Brewfile dependency failed to install.
```

But that's really ok, just keep moving along.