### PR TITLE
brew-macos-vscode-codespaces: install VSCode extensions.

### DIFF
--- a/cmd/brew-macos-vscode-codespaces
+++ b/cmd/brew-macos-vscode-codespaces
@@ -39,5 +39,23 @@ if launchctl list | grep -q nginx; then
   brew services stop nginx
 fi
 
+
+# Install VS Code extensions.
+PATH="/usr/local/bin:/Applications/Visual Studio Code.app/Contents/Resources/app/bin:$PATH"
+INSTALLED_EXTENSIONS="$(code --list-extensions)"
+NEEDED_EXTENSIONS=<<EOS
+GitHub.codespaces
+EOS
+
+for EXTENSION in $NEEDED_EXTENSIONS
+do
+  if echo "$EXTENSIONS" | grep -q "$EXTENSION"
+  then
+    continue
+  fi
+
+  code --install-extension "$EXTENSION"
+done
+
 # Run VS Code.
 open -b com.microsoft.VSCode


### PR DESCRIPTION
Only one currently but make it easy to add more in future.