### PR TITLE
Fix M1 issue and a couple of bugs in brew-macos-vscode-codespaces

### DIFF
--- a/cmd/brew-macos-vscode-codespaces
+++ b/cmd/brew-macos-vscode-codespaces
@@ -16,16 +16,18 @@ if [ ! -x "$(command -v brew 2>/dev/null)" ]; then
   exit 1
 fi
 
+HOMEBREW_PREFIX="${HOMEBREW_PREFIX:-/usr/local}"
+
 # Link launchdns' configuration.
-if [ "$(readlink /etc/resolver)" != "/usr/local/etc/resolver" ] ||
+if [ "$(readlink /etc/resolver)" != "${HOMEBREW_PREFIX}/etc/resolver" ] ||
    [ ! -L "/etc/resolver" ]; then
   if ! sudo -n true >/dev/null; then
     echo "We need your user's password to link /etc/resolver with sudo:"
     /usr/bin/sudo -v 2>/dev/null
   fi
-  echo "==> Linking /usr/local/etc/resolver to /etc/resolver"
+  echo "==> Linking ${HOMEBREW_PREFIX}/etc/resolver to /etc/resolver"
   sudo rm -rf /etc/resolver
-  sudo ln -s /usr/local/etc/resolver /etc
+  sudo ln -s "${HOMEBREW_PREFIX}/etc/resolver" /etc
 fi
 
 # Install launchdns and VS Code.
@@ -41,7 +43,7 @@ fi
 
 
 # Install VS Code extensions.
-PATH="/usr/local/bin:/Applications/Visual Studio Code.app/Contents/Resources/app/bin:$PATH"
+PATH="${HOMEBREW_PREFIX}/bin:/Applications/Visual Studio Code.app/Contents/Resources/app/bin:$PATH"
 INSTALLED_EXTENSIONS="$(code --list-extensions)"
 NEEDED_EXTENSIONS=<<EOS
 GitHub.codespaces

--- a/cmd/brew-macos-vscode-codespaces
+++ b/cmd/brew-macos-vscode-codespaces
@@ -45,13 +45,14 @@ fi
 # Install VS Code extensions.
 PATH="${HOMEBREW_PREFIX}/bin:/Applications/Visual Studio Code.app/Contents/Resources/app/bin:$PATH"
 INSTALLED_EXTENSIONS="$(code --list-extensions)"
-NEEDED_EXTENSIONS=<<EOS
+NEEDED_EXTENSIONS=$(cat <<'EOS'
 GitHub.codespaces
 EOS
+)
 
 for EXTENSION in $NEEDED_EXTENSIONS
 do
-  if echo "$EXTENSIONS" | grep -q "$EXTENSION"
+  if echo "$INSTALLED_EXTENSIONS" | grep -q "$EXTENSION"
   then
     continue
   fi

--- a/cmd/brew-macos-vscode-codespaces
+++ b/cmd/brew-macos-vscode-codespaces
@@ -16,6 +16,7 @@ if [ ! -x "$(command -v brew 2>/dev/null)" ]; then
   exit 1
 fi
 
+HOMEBREW_PREFIX="$(brew --prefix)"
 HOMEBREW_PREFIX="${HOMEBREW_PREFIX:-/usr/local}"
 
 # Link launchdns' configuration.


### PR DESCRIPTION
Came here to make the script play a bit nicer on M1, but found a couple of unrelated bugs in the process, so there are two commits here. This is my first PR in this repo so please let me know if I'm doing anything wrong. 😁 

Not fixed in this commit: the fact that `launchdns` currently doesn't install on M1 due to:

```
Error: launchdns: no bottle available!
```

I just installed it from source instead:

```sh
brew install --build-from-source launchdns
```
---

### Respect HOMEBREW_PREFIX in brew-macos-vscode-codespaces

I have my Homebrew files in `/opt/homebrew` because I'm running on an M1, but the script is hard-coded to assume `/usr/local`. As such, the script tries to set the symlink from `/usr/local/etc/resolver` to `/etc/resolver`, and it ends up being a non-existent source.

The fix is to use `$HOMEBREW_PREFIX` if set, and fallback to `/usr/local` otherwise.

Further down the file, we also use the `$HOMEBREW_PREFIX` to prepend `/opt/homebrew/bin` or `/usr/local/bin` to the `$PATH` rather than hard-coding `/usr/local/bin`. In practice, however, this probably doesn't matter because if whatever your `$HOMEBREW_PREFIX` is, `$HOMEBREW_PREFIX/bin` is probably already in your `$PATH` by the time you run `brew macos-vscode-codespaces`. I fixed it anyway.

### Fix extension installation in brew-macos-vscode-codespaces

While testing the previous commit, I noticed that this script isn't actually installing any extensions. There are two problems.

First is that we can't assign a multiline string to the `NEEDED_EXTENSIONS` variable like that. The `for` loop body was never being entered, as a result. We instead have to use one of the [techniques listed here](https://stackoverflow.com/questions/1167746/how-to-assign-a-heredoc-value-to-a-variable-in-bash).

I would have used [the `read` technique](https://stackoverflow.com/a/1655389), as it avoids forking a useless subshell, but it causes the script to die because we are using `set -e` and `read` exits with a status of `1` at EOF, as [explained in this comment](https://stackoverflow.com/questions/1167746/how-to-assign-a-heredoc-value-to-a-variable-in-bash#comment7650320_1655389).

So, instead, using [this alternative technique](https://stackoverflow.com/a/1168084).

The second problem with the script is that we are feeding a non-existent variable (`$EXTENSIONS`) into our `grep` invocation, meaning that we failed to correctly detect an existing install. The fix is to use `$INSTALLED_EXTENSIONS` instead.

**Test plan:** Copy the changed script to `/opt/homebrew/Library/Taps/github/homebrew-bootstrap/cmd/` and run `brew macos-vscode-codespaces`. I sprinkled some `echo` through the file to see it enter the loop and exit appropriately. It only installs on the first run.